### PR TITLE
remove bad function

### DIFF
--- a/openreview_matcher/matcher.py
+++ b/openreview_matcher/matcher.py
@@ -8,10 +8,6 @@ import openreview
 from collections import defaultdict
 
 
-def get_assignments(config_id, client=openreview.Client()):
-    # solving the matcher returns a configuration note object with the content.assignments field filled in.
-    return Matcher(config_note=client.get_note(config_id)).solve()
-
 class Matcher(object):
 
     def __init__(self, client):


### PR DESCRIPTION
the default value for "client" in this function causes an error on import, even when the function is not being used. finding this bug made me realize that this function shouldn't even really exist in the first place.