### PR TITLE
Feature/support submission invitation filters

### DIFF
--- a/matcher/__main__.py
+++ b/matcher/__main__.py
@@ -92,7 +92,7 @@ if args.constraints:
             constraint = row[2]
 
             reviewer_set.update([profile_id])
-            paper_set.append([paper_id])
+            paper_set.update([paper_id])
 
             constraints.append((paper_id, profile_id, constraint))
 

--- a/matcher/encoder.py
+++ b/matcher/encoder.py
@@ -120,7 +120,7 @@ class Encoder:
             if not constraint in [-1, 0, 1]:
                 raise ValueError(
                     'constraint {} ({}, {}) must be an int of value -1, 0, or 1'.format(
-                        constraint, forum, user, type(constraint)))
+                        constraint, forum, user))
 
             # sometimes papers or reviewers get deleted after constraint_edges are created,
             # so we need to check that the head/tail are still valid

--- a/matcher/service/openreview_interface.py
+++ b/matcher/service/openreview_interface.py
@@ -140,8 +140,24 @@ class ConfigNoteInterface:
     @property
     def paper_notes(self):
         if not 'paper_notes' in self._cache:
+            content_dict = {}
+            paper_invitation = self.config_note.content['paper_invitation']
+            self.logger.debug('Getting notes for invitation: {}'.format(paper_invitation))
+            if '&' in paper_invitation:
+                elements = paper_invitation.split('&')
+                paper_invitation = elements[0]
+                for element in elements[1:]:
+                    if element:
+                        if element.startswith('content.') and '=' in element:
+                            key, value = element.split('.')[1].split('=')
+                            content_dict[key] = value
+                        else:
+                            self.logger.debug('Invalid filter provided in invitation: {}. Supported filter format "content.field_x=value1".'.format(element))
             self._cache['paper_notes'] = list(openreview.tools.iterget_notes(
-                self.client, invitation=self.config_note.content['paper_invitation']))
+                self.client,
+                invitation=paper_invitation,
+                content = content_dict))
+            self.logger.debug('Count of notes found: {}'.format(len(self._cache['paper_notes'])))
 
         return self._cache['paper_notes']
 


### PR DESCRIPTION
This allows match invitation to specify a filter over submissions.

We are expecting the filters to be content.XXX format. e.g. ICLR.cc/2020/Conference/-/Blind_Submission&content.paper_type=Full Paper

This requires the change https://github.com/openreview/openreview/pull/1877 to be implemented first to work.