### PR TITLE
Fix/remove bid normalization

### DIFF
--- a/matcher/core.py
+++ b/matcher/core.py
@@ -37,7 +37,7 @@ class KeywordDatasource:
         self.maximums = maximums
         self.demands = demands
         self.num_alternates = num_alternates
-        self.should_normalize = False
+        self.normalization_types = []
 
 class Matcher:
     '''Main class that coordinates an Encoder and a Solver.'''
@@ -95,7 +95,7 @@ class Matcher:
             constraints=self.datasource.constraints,
             scores_by_type=self.datasource.scores_by_type,
             weight_by_type=self.datasource.weight_by_type,
-            use_normalization=self.datasource.should_normalize
+            normalization_types=self.datasource.normalization_types
         )
 
         self.logger.debug('Preparing solver')

--- a/matcher/encoder.py
+++ b/matcher/encoder.py
@@ -87,14 +87,16 @@ class Encoder:
         self.cost_matrix = _score_to_cost(self.aggregate_score_matrix)
 
     def _normalize(self, weight_by_type, score_matrices):
-        indicator = { score_type: scores != 0.0  for score_type, scores in score_matrices.items() }
+        indicator = { score_type: scores != 0.0  for score_type, scores in score_matrices.items() if not score_type.endswith('Bid')}
         sum_of_weights = sum([
             indicator * weight_by_type[score_type] for score_type, indicator in indicator.items()
         ])
         normalizer = np.where(sum_of_weights == 0, 0, 1/sum_of_weights)
 
-        return normalizer * sum([
-            scores * weight_by_type[score_type] for score_type, scores in score_matrices.items()
+        return (normalizer * sum([
+            scores * weight_by_type[score_type] for score_type, scores in score_matrices.items() if not score_type.endswith('Bid')
+        ])) + sum([
+            scores * weight_by_type[score_type] for score_type, scores in score_matrices.items() if score_type.endswith('Bid')
         ])
 
 

--- a/matcher/service/openreview_interface.py
+++ b/matcher/service/openreview_interface.py
@@ -117,8 +117,10 @@ class ConfigNoteInterface:
                 raise error_handle
 
     @property
-    def should_normalize(self):
-        return self.config_note.content.get('scores_normalization', 'No') == 'Yes'
+    def normalization_types(self):
+        scores_specification = self.config_note.content.get('scores_specification', {})
+        normalization_types = [invitation for invitation, spec in scores_specification.items() if spec.get('normalize', False)]
+        return normalization_types
 
     @property
     def match_group(self):

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -290,12 +290,27 @@ def test_encoder_average_weighting(encoder_context):
             (3, 2, 1),
             (3, 3, 0.5),
             (3, 4, 0.8)
+        ],
+        'Bid': [
+            (1, 1, 0),
+            (1, 2, 1),
+            (1, 3, 1),
+            (1, 4, 1),
+            (2, 1, 0),
+            (2, 2, -1),
+            (2, 3, 1),
+            (2, 4, -0.5),
+            (3, 1, 0),
+            (3, 2, 1),
+            (3, 3, 0.5),
+            (3, 4, 0.75)
         ]
     }
 
     weight_by_type = {
         'TPMS': 0.8,
-        'Affinity': 0.2
+        'Affinity': 0.2,
+        'Bid': 1
     }
 
     constraints = []
@@ -306,16 +321,21 @@ def test_encoder_average_weighting(encoder_context):
         constraints,
         scores_by_type,
         weight_by_type,
-        use_normalization=True
+        ['TPMS', 'Affinity']
     )
 
     def assert_arrays(array_A, array_B):
-        assert all([a == b for a, b in zip(array_A, array_B)]), array_A + array_B
+        assert all([float(a) == float(b) for a, b in zip(array_A, array_B)])
 
     encoded_aggregate_matrix = encoder.aggregate_score_matrix
     print(encoded_aggregate_matrix)
-    expected_matrix = [[0, 1, 1, 1], [0.7, 1, 1, 1], [0.6, 1, 0.9, 0.4]]
+    expected_matrix = [
+        [0, 2, 2, 2],
+        [0.7, 0, 2, 0.5],
+        [0.6, 2, 1.4, 1.15]
+    ]
+    print('expected', expected_matrix)
 
-    for a, b in zip(encoded_aggregate_matrix, expected_matrix):
-        assert_arrays(a, b)
+    for a in range(0,3):
+        assert_arrays(encoded_aggregate_matrix[a], expected_matrix[a])
 


### PR DESCRIPTION
Use an array of normalization scores instead of a boolean value. The PCs can decide which scores to normalize.