### PR TITLE
read groups instead of papers

### DIFF
--- a/matcher/service/openreview_interface.py
+++ b/matcher/service/openreview_interface.py
@@ -19,7 +19,7 @@ class ConfigNoteInterface:
         self.logger.debug('GET invitation id={}'.format(self.config_note.content['aggregate_score_invitation']))
         self.aggregate_score_invitation = self.client.get_invitation(self.config_note.content['aggregate_score_invitation'])
         self.num_alternates = int(self.config_note.content['alternates'])
-        self.paper_notes = []
+        self.paper_numbers = {}
         self.allow_zero_score_assignments = (self.config_note.content.get('allow_zero_score_assignments', 'No') == 'Yes')
 
         # Lazy variables
@@ -72,12 +72,19 @@ class ConfigNoteInterface:
                             content_dict[key] = value
                         else:
                             self.logger.debug('Invalid filter provided in invitation: {}. Supported filter format "content.field_x=value1".'.format(element))
-            self.paper_notes = list(openreview.tools.iterget_notes(
-                self.client,
-                invitation=paper_invitation,
-                content=content_dict))
-            self._papers = [n.id for n in self.paper_notes]
-            self.logger.debug('Count of notes found: {}'.format(len(self._papers)))
+            if '/-/' in paper_invitation:
+                paper_notes = list(openreview.tools.iterget_notes(
+                    self.client,
+                    invitation=paper_invitation,
+                    content=content_dict))
+                self._papers = [n.id for n in paper_notes]
+                self.paper_numbers = { n.id : n.number for n in paper_notes }
+                self.logger.debug('Count of notes found: {}'.format(len(self._papers)))
+            else:
+                self.logger.debug('GET group id={}'.format(paper_invitation))
+                group = self.client.get_group(paper_invitation)
+                self._papers = group.members
+                self.paper_numbers = { n: 1 for n in group.members }
 
         return self._papers
 
@@ -201,7 +208,6 @@ class ConfigNoteInterface:
 
     def set_assignments(self, assignments_by_forum):
         '''Helper function for posting assignments returned by the Encoder'''
-        paper_by_forum = {n.forum: n for n in self.paper_notes}
 
         self.logger.debug('saving {} edges'.format(self.assignment_invitation.id))
 
@@ -209,7 +215,7 @@ class ConfigNoteInterface:
         score_edges = []
 
         for forum, assignments in assignments_by_forum.items():
-            paper = paper_by_forum[forum]
+            paper_number = self.paper_numbers[forum]
             for paper_user_entry in assignments:
                 score = paper_user_entry['aggregate_score']
                 user = paper_user_entry['user']
@@ -221,7 +227,7 @@ class ConfigNoteInterface:
                         user,
                         score,
                         self.label,
-                        paper.number
+                        paper_number
                     )
                 )
 
@@ -232,7 +238,7 @@ class ConfigNoteInterface:
                         user,
                         score,
                         self.label,
-                        paper.number
+                        paper_number
                     )
                 )
 
@@ -244,11 +250,9 @@ class ConfigNoteInterface:
     def set_alternates(self, alternates_by_forum):
         '''Helper function for posting alternates returned by the Encoder'''
 
-        paper_by_forum = {n.forum: n for n in self.paper_notes}
-
         score_edges = []
         for forum, assignments in alternates_by_forum.items():
-            paper = paper_by_forum[forum]
+            paper_number = self.paper_numbers[forum]
 
             for paper_user_entry in assignments:
                 score = paper_user_entry['aggregate_score']
@@ -261,7 +265,7 @@ class ConfigNoteInterface:
                         user,
                         score,
                         self.label,
-                        paper.number
+                        paper_number
                     )
                 )
 

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -115,7 +115,7 @@ def test_confignote_interface():
                     content={
                         'title': 'test-1',
                         'match_group': '<match_group_id>',
-                        'paper_invitation': '<paper_invitation_id>',
+                        'paper_invitation': '<venue/-/paper_invitation_id>',
                         'user_demand': 1,
                         'min_papers': 1,
                         'max_papers': 2,
@@ -140,13 +140,13 @@ def test_confignote_interface():
                         'status': None
                     }
                 ),
-            '<paper_invitation_id>': [
+            '<venue/-/paper_invitation_id>': [
                 openreview.Note(
                         id='paper0',
                         readers=[],
                         writers=[],
                         signatures=[],
-                        invitation='<paper_invitation_id>',
+                        invitation='<venue/-/paper_invitation_id>',
                         content={}
                     ),
                 openreview.Note(
@@ -154,7 +154,7 @@ def test_confignote_interface():
                         readers=[],
                         writers=[],
                         signatures=[],
-                        invitation='<paper_invitation_id>',
+                        invitation='<venue/-/paper_invitation_id>',
                         content={}
                     ),
                 openreview.Note(
@@ -162,7 +162,7 @@ def test_confignote_interface():
                         readers=[],
                         writers=[],
                         signatures=[],
-                        invitation='<paper_invitation_id>',
+                        invitation='<venue/-/paper_invitation_id>',
                         content={}
                     )
                 ]
@@ -392,7 +392,7 @@ def test_confignote_interface_backward_compat_max_users():
                     content={
                         'title': 'test-1',
                         'match_group': '<match_group_id>',
-                        'paper_invitation': '<paper_invitation_id>',
+                        'paper_invitation': '<venue/-/paper_invitation_id>',
                         'max_users': 1,
                         'min_papers': 1,
                         'max_papers': 2,
@@ -417,13 +417,13 @@ def test_confignote_interface_backward_compat_max_users():
                         'status': None
                     }
                 ),
-            '<paper_invitation_id>': [
+            '<venue/-/paper_invitation_id>': [
                 openreview.Note(
                         id='paper0',
                         readers=[],
                         writers=[],
                         signatures=[],
-                        invitation='<paper_invitation_id>',
+                        invitation='<venue/-/paper_invitation_id>',
                         content={}
                     ),
                 openreview.Note(
@@ -431,7 +431,7 @@ def test_confignote_interface_backward_compat_max_users():
                         readers=[],
                         writers=[],
                         signatures=[],
-                        invitation='<paper_invitation_id>',
+                        invitation='<venue/-/paper_invitation_id>',
                         content={}
                     ),
                 openreview.Note(
@@ -439,7 +439,7 @@ def test_confignote_interface_backward_compat_max_users():
                         readers=[],
                         writers=[],
                         signatures=[],
-                        invitation='<paper_invitation_id>',
+                        invitation='<venue/-/paper_invitation_id>',
                         content={}
                     )
                 ]
@@ -676,7 +676,7 @@ def test_confignote_interface_custom_demand_edges():
                     content={
                         'title': 'test-1',
                         'match_group': '<match_group_id>',
-                        'paper_invitation': '<paper_invitation_id>',
+                        'paper_invitation': '<venue/-/paper_invitation_id>',
                         'user_demand': 1,
                         'min_papers': 1,
                         'max_papers': 2,
@@ -700,13 +700,13 @@ def test_confignote_interface_custom_demand_edges():
                         'status': None
                     }
                 ),
-            '<paper_invitation_id>': [
+            '<venue/-/paper_invitation_id>': [
                 openreview.Note(
                         id='paper0',
                         readers=[],
                         writers=[],
                         signatures=[],
-                        invitation='<paper_invitation_id>',
+                        invitation='<venue/-/paper_invitation_id>',
                         content={}
                     ),
                 openreview.Note(
@@ -714,7 +714,7 @@ def test_confignote_interface_custom_demand_edges():
                         readers=[],
                         writers=[],
                         signatures=[],
-                        invitation='<paper_invitation_id>',
+                        invitation='<venue/-/paper_invitation_id>',
                         content={}
                     ),
                 openreview.Note(
@@ -722,7 +722,7 @@ def test_confignote_interface_custom_demand_edges():
                         readers=[],
                         writers=[],
                         signatures=[],
-                        invitation='<paper_invitation_id>',
+                        invitation='<venue/-/paper_invitation_id>',
                         content={}
                     )
                 ]
@@ -932,7 +932,7 @@ def test_confignote_missing_edges_spec():
                     content={
                         'title': 'test-1',
                         'match_group': '<match_group_id>',
-                        'paper_invitation': '<paper_invitation_id>',
+                        'paper_invitation': '<venue/-/paper_invitation_id>',
                         'user_demand': 1,
                         'min_papers': 1,
                         'max_papers': 1,
@@ -957,13 +957,13 @@ def test_confignote_missing_edges_spec():
                         'status': None
                     }
                 ),
-            '<paper_invitation_id>': [
+            '<venue/-/paper_invitation_id>': [
                 openreview.Note(
                         id='paper0',
                         readers=[],
                         writers=[],
                         signatures=[],
-                        invitation='<paper_invitation_id>',
+                        invitation='<venue/-/paper_invitation_id>',
                         content={}
                     ),
                 openreview.Note(
@@ -971,7 +971,7 @@ def test_confignote_missing_edges_spec():
                         readers=[],
                         writers=[],
                         signatures=[],
-                        invitation='<paper_invitation_id>',
+                        invitation='<venue/-/paper_invitation_id>',
                         content={}
                     ),
                 openreview.Note(
@@ -979,7 +979,7 @@ def test_confignote_missing_edges_spec():
                         readers=[],
                         writers=[],
                         signatures=[],
-                        invitation='<paper_invitation_id>',
+                        invitation='<venue/-/paper_invitation_id>',
                         content={}
                     )
                 ]
@@ -1151,7 +1151,7 @@ def test_confignote_interface_no_scores_spec():
                     content={
                         'title': 'test-1',
                         'match_group': '<match_group_id>',
-                        'paper_invitation': '<paper_invitation_id>',
+                        'paper_invitation': '<venue/-/paper_invitation_id>',
                         'user_demand': 1,
                         'min_papers': 1,
                         'max_papers': 1,
@@ -1163,13 +1163,13 @@ def test_confignote_interface_no_scores_spec():
                         'status': None
                     }
                 ),
-            '<paper_invitation_id>': [
+            '<venue/-/paper_invitation_id>': [
                 openreview.Note(
                         id='paper0',
                         readers=[],
                         writers=[],
                         signatures=[],
-                        invitation='<paper_invitation_id>',
+                        invitation='<venue/-/venue/-/paper_invitation_id>',
                         content={}
                     ),
                 openreview.Note(
@@ -1177,7 +1177,7 @@ def test_confignote_interface_no_scores_spec():
                         readers=[],
                         writers=[],
                         signatures=[],
-                        invitation='<paper_invitation_id>',
+                        invitation='<venue/-/paper_invitation_id>',
                         content={}
                     ),
                 openreview.Note(
@@ -1185,7 +1185,7 @@ def test_confignote_interface_no_scores_spec():
                         readers=[],
                         writers=[],
                         signatures=[],
-                        invitation='<paper_invitation_id>',
+                        invitation='<venue/-/paper_invitation_id>',
                         content={}
                     )
                 ]
@@ -1324,7 +1324,7 @@ def test_confignote_interface_custom_load_negative():
                     content={
                         'title': 'test-1',
                         'match_group': '<match_group_id>',
-                        'paper_invitation': '<paper_invitation_id>',
+                        'paper_invitation': '<venue/-/paper_invitation_id>',
                         'user_demand': 1,
                         'min_papers': 1,
                         'max_papers': 1,
@@ -1347,13 +1347,13 @@ def test_confignote_interface_custom_load_negative():
                         'status': None
                     }
                 ),
-            '<paper_invitation_id>': [
+            '<venue/-/paper_invitation_id>': [
                 openreview.Note(
                         id='paper0',
                         readers=[],
                         writers=[],
                         signatures=[],
-                        invitation='<paper_invitation_id>',
+                        invitation='<venue/-/paper_invitation_id>',
                         content={}
                     ),
                 openreview.Note(
@@ -1361,7 +1361,7 @@ def test_confignote_interface_custom_load_negative():
                         readers=[],
                         writers=[],
                         signatures=[],
-                        invitation='<paper_invitation_id>',
+                        invitation='<venue/-/paper_invitation_id>',
                         content={}
                     ),
                 openreview.Note(
@@ -1369,7 +1369,7 @@ def test_confignote_interface_custom_load_negative():
                         readers=[],
                         writers=[],
                         signatures=[],
-                        invitation='<paper_invitation_id>',
+                        invitation='<venue/-/paper_invitation_id>',
                         content={}
                     )
                 ]
@@ -1557,7 +1557,7 @@ def test_confignote_interface_custom_overload():
                     content={
                         'title': 'test-1',
                         'match_group': '<match_group_id>',
-                        'paper_invitation': '<paper_invitation_id>',
+                        'paper_invitation': '<venue/-/paper_invitation_id>',
                         'user_demand': 1,
                         'min_papers': 1,
                         'max_papers': 1,
@@ -1580,13 +1580,13 @@ def test_confignote_interface_custom_overload():
                         'status': None
                     }
                 ),
-            '<paper_invitation_id>': [
+            '<venue/-/paper_invitation_id>': [
                 openreview.Note(
                         id='paper0',
                         readers=[],
                         writers=[],
                         signatures=[],
-                        invitation='<paper_invitation_id>',
+                        invitation='<venue/-/paper_invitation_id>',
                         content={}
                     ),
                 openreview.Note(
@@ -1594,7 +1594,7 @@ def test_confignote_interface_custom_overload():
                         readers=[],
                         writers=[],
                         signatures=[],
-                        invitation='<paper_invitation_id>',
+                        invitation='<venue/-/paper_invitation_id>',
                         content={}
                     ),
                 openreview.Note(
@@ -1602,7 +1602,7 @@ def test_confignote_interface_custom_overload():
                         readers=[],
                         writers=[],
                         signatures=[],
-                        invitation='<paper_invitation_id>',
+                        invitation='<venue/-/paper_invitation_id>',
                         content={}
                     )
                 ]

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -1719,3 +1719,263 @@ def test_confignote_interface_custom_overload():
         else:
             assert interface.maximums[reviewer_index] == interface.config_note.content['max_papers']
 
+
+def test_confignote_interface_matching_users():
+    '''Test of basic ConfigNoteInterface functionality.'''
+
+    mock_openreview_data = {
+        'paper_ids': ['ac0', 'ac1', 'ac2'],
+        'reviewer_ids': ['sac0', 'sac1', 'sac2', 'sac3'],
+        'mock_invitations': {
+            '<assignment_invitation_id>': openreview.Invitation(
+                    id='<assignment_invitation_id>',
+                    writers=[],
+                    readers=[],
+                    signatures=[],
+                    reply={}
+                ),
+            '<aggregate_score_invitation_id>': openreview.Invitation(
+                    id='<aggregate_score_invitation_id>',
+                    writers=[],
+                    readers=[],
+                    signatures=[],
+                    reply={}
+                ),
+            '<custom_max_papers_invitation_id>': openreview.Invitation(
+                    id='<custom_max_papers_invitation_id>',
+                    writers=[],
+                    readers=[],
+                    signatures=[],
+                    reply={}
+                ),
+            '<conflicts_invitation_id>': openreview.Invitation(
+                    id='<conflicts_invitation_id>',
+                    writers=[],
+                    readers=[],
+                    signatures=[],
+                    reply={}
+                ),
+            '<affinity_score_invitation>': openreview.Invitation(
+                    id='<affinity_score_invitation>',
+                    writers=[],
+                    readers=[],
+                    signatures=[],
+                    reply={}
+                ),
+            '<bid_invitation>': openreview.Invitation(
+                    id='<bid_invitation>',
+                    writers=[],
+                    readers=[],
+                    signatures=[],
+                    reply={}
+                ),
+        },
+        'mock_groups': {
+            '<match_group_id>': openreview.Group(
+                    id='<match_group_id>',
+                    writers=[],
+                    readers=[],
+                    signatures=[],
+                    signatories=[],
+                    members=['sac0', 'sac1', 'sac2', 'sac3']
+                ),
+            '<ac_group_id>': openreview.Group(
+                    id='<ac_group_id>',
+                    readers=[],
+                    writers=[],
+                    signatures=[],
+                    members=['ac0', 'ac1', 'ac2'],
+                    signatories=[]
+                )
+        },
+        'mock_notes': {
+            '<config_note_id>': openreview.Note(
+                    id='<config_note_id>',
+                    readers=[],
+                    writers=[],
+                    signatures=['<match_group_id>'],
+                    invitation='<config_note_invitation>',
+                    content={
+                        'title': 'test-1',
+                        'match_group': '<match_group_id>',
+                        'paper_invitation': '<ac_group_id>',
+                        'user_demand': 1,
+                        'min_papers': 1,
+                        'max_papers': 2,
+                        'alternates': 1,
+                        'conflicts_invitation': '<conflicts_invitation_id>',
+                        'scores_specification': {
+                            '<affinity_score_invitation>': {
+                                'weight': 1
+                            },
+                            '<bid_invitation>': {
+                                'default': 0.5,
+                                'weight': 2,
+                                'translate_map': {
+                                    'High': 1,
+                                    'Very Low': -1
+                                }
+                            }
+                        },
+                        'assignment_invitation': '<assignment_invitation_id>',
+                        'aggregate_score_invitation': '<aggregate_score_invitation_id>',
+                        'custom_max_papers_invitation': '<custom_max_papers_invitation_id>',
+                        'status': None
+                    }
+                )
+        },
+        'mock_grouped_edges': {
+            '<affinity_score_invitation>': [
+                {
+                    'id': {'head': 'ac0'},
+                    'values': [
+                        {'tail': 'sac0', 'weight': random.random()},
+                        {'tail': 'sac1', 'weight': random.random()},
+                        {'tail': 'sac2', 'weight': random.random()},
+                        {'tail': 'sac3', 'weight': random.random()},
+                    ]
+                },
+                {
+                    'id': {'head': 'ac1'},
+                    'values': [
+                        {'tail': 'sac0', 'weight': random.random()},
+                        {'tail': 'sac1', 'weight': random.random()},
+                        {'tail': 'sac2', 'weight': random.random()},
+                        {'tail': 'sac3', 'weight': random.random()},
+                    ]
+                },
+                {
+                    'id': {'head': 'ac2'},
+                    'values': [
+                        {'tail': 'sac0', 'weight': random.random()},
+                        {'tail': 'sac1', 'weight': random.random()},
+                        {'tail': 'sac2', 'weight': random.random()},
+                        {'tail': 'sac3', 'weight': random.random()},
+                    ]
+                }
+            ],
+            '<bid_invitation>': [
+                {
+                    'id': {'head': 'ac0'},
+                    'values': [
+                        {'tail': 'sac0', 'weight': None, 'label': 'High'},
+                        {'tail': 'sac2', 'weight': None, 'label': 'Very Low'},
+                        {'tail': 'sac3', 'weight': None, 'label': 'High'},
+                    ]
+                },
+                {
+                    'id': {'head': 'ac1'},
+                    'values': [
+                        {'tail': 'sac0', 'weight': None, 'label': 'High'},
+                        {'tail': 'sac1', 'weight': None, 'label': 'High'},
+                        {'tail': 'sac3', 'weight': None, 'label': 'Very Low'},
+                    ]
+                },
+                {
+                    'id': {'head': 'ac2'},
+                    'values': [
+                        {'tail': 'sac0', 'weight': None, 'label': 'Very Low'},
+                        {'tail': 'sac1', 'weight': None, 'label': 'High'},
+                        {'tail': 'sac2', 'weight': None, 'label': 'High'},
+                        {'tail': 'sac3', 'weight': None, 'label': 'High'},
+                    ]
+                }
+            ],
+            '<conflicts_invitation_id>': [
+                {
+                    'id': {'head': 'ac0'},
+                    'values': [
+                        {'tail': 'sac0', 'weight': 0},
+                        {'tail': 'sac1', 'weight': 1},
+                        {'tail': 'sac2', 'weight': 0},
+                        {'tail': 'sac3', 'weight': 0},
+                    ]
+                },
+                {
+                    'id': {'head': 'ac1'},
+                    'values': [
+                        {'tail': 'sac0', 'weight': 0},
+                        {'tail': 'sac1', 'weight': 0},
+                        {'tail': 'sac2', 'weight': 1},
+                        {'tail': 'sac3', 'weight': 0},
+                    ]
+                },
+                {
+                    'id': {'head': 'ac2'},
+                    'values': [
+                        {'tail': 'sac0', 'weight': 0},
+                        {'tail': 'sac1', 'weight': 0},
+                        {'tail': 'sac2', 'weight': 0},
+                        {'tail': 'sac3', 'weight': 1},
+                    ]
+                }
+            ],
+            '<custom_max_papers_invitation_id>': [
+                {
+                    'id': {'head': '<match_group_id>'},
+                    'values': [
+                        {'tail': 'sac0', 'weight': 1},
+                        {'tail': 'sac3', 'weight': 3}
+                    ]
+                }
+            ]
+        }
+    }
+
+    client = mock_client(**mock_openreview_data)
+
+    interface = ConfigNoteInterface(client, '<config_note_id>')
+
+    assert interface.config_note
+    assert_arrays(interface.reviewers, ['sac0', 'sac1', 'sac2', 'sac3'], is_string=True)
+    assert_arrays(interface.papers, ['ac0', 'ac1', 'ac2'], is_string=True)
+    assert_arrays(interface.minimums, [1,1,1,1])
+    assert_arrays(interface.maximums, [1,2,2,2])
+    assert_arrays(interface.demands, [1,1,1])
+    assert interface.constraints
+    valid_constraint_pairs = [('ac0', 'sac1'), ('ac1', 'sac2'), ('ac2', 'sac3')]
+    for (ac,sac,constraint) in interface.constraints:
+        if (ac,sac) in valid_constraint_pairs:
+            assert constraint == 1
+        else:
+            assert constraint == 0
+    assert interface.scores_by_type
+    assert len(interface.scores_by_type) == 2
+    map_defaults = {
+        '<bid_invitation>': 0.5,
+        '<affinity_score_invitation>': 0
+    }
+    for invitation, scores in interface.scores_by_type.items():
+        assert 'edges' in scores
+        assert 'default' in scores
+        assert map_defaults[invitation] == scores['default']
+        assert invitation in ['<bid_invitation>', '<affinity_score_invitation>']
+
+    very_low_bids = [
+        ('ac0', 'sac2'),
+        ('ac1', 'sac3'),
+        ('ac2', 'sac0')]
+    high_bids = [
+        ('acr0', 'sac0'),
+        ('ac0', 'sac3'),
+        ('ac1', 'sac0'),
+        ('ac1', 'sac1'),
+        ('ac2', 'sac1'),
+        ('ac2', 'sac2')]
+    for ac, sac, bid in interface.scores_by_type['<bid_invitation>']['edges']:
+        if (ac, sac) in very_low_bids:
+            assert bid == -1
+        elif (ac, sac) in high_bids:
+            assert bid == 1
+
+    for invitation in interface.weight_by_type:
+        assert invitation in ['<bid_invitation>', '<affinity_score_invitation>']
+    assert_arrays(list(interface.weight_by_type.values()), [1, 2])
+
+    assert len(interface.weight_by_type) == 2
+    assert interface.assignment_invitation
+    assert interface.aggregate_score_invitation
+
+    interface.set_status(MatcherStatus.RUNNING)
+    assert interface.config_note.content['status'] == 'Running'
+


### PR DESCRIPTION
Support assignments between members of different groups, for example: SAC vs AC. 