### PR TITLE
Fix rounding in randomized_solver

### DIFF
--- a/matcher/solvers/bvn_extension/bvn.c
+++ b/matcher/solvers/bvn_extension/bvn.c
@@ -19,16 +19,9 @@
 #include <math.h>
 #include <assert.h>
 
-/* Input flows are rounded to round(flow * one) and these probabilities
- * are then sampled from. If this truncation takes the fractional assignment
- * out of the legal polytope then sampled assignments may be invalid as
- * well. Defined so that one = 10^dig.
- */
-#define one 10000000
-#define dig 7
-
 #define debug 0
 
+int one;
 
 /* STATE VARIABLES */
 
@@ -83,19 +76,21 @@ void free_buffers(void);
  * Arguments:
  * - flows: The row-major flattened fractional assignment matrix
  *   (size npaps * nrevs). The function modifies this buffer so that it contains
- *   the output sampled assignment.
+ *   the output sampled assignment. Input flows are scaled up by one_ to be integers.
  * - subsets: An array of size nrevs containing a strictly positive subset ID
  *   for each reviewer. Reviewers in the same subset are not assigned to the
  *   same paper if possible. Currently unused by the Python interface.
  * - npaps: Number of papers.
  * - nrevs: Number of reviewers.
+ * - one_: Scale of flows.
  */
-int run_bvn(double* flows, int* subsets, int npaps, int nrevs)
+int run_bvn(int* flows, int* subsets, int npaps, int nrevs, int one_)
 {
     srand(clock()); // set random seed to current clock time
     rand(); // throw away first random number
 
     int n = npaps + nrevs;
+	one = one_;
 
 	// allocate space for n vertices, and 2*p*r maximum edges
 	initialize_state(n + 1, (2 * npaps * nrevs) + 1);
@@ -106,7 +101,7 @@ int run_bvn(double* flows, int* subsets, int npaps, int nrevs)
     {
 		int x = idx_to_rev(i, npaps, nrevs);
 		int y = idx_to_pap(i, npaps, nrevs);
-		int z = round(flows[i] * one);
+		int z = flows[i];//round(flows[i] * one);
 
         c[x] += z; // update load counters at vertices
         c[y] -= z;

--- a/matcher/solvers/bvn_extension/bvn_extension_build.py
+++ b/matcher/solvers/bvn_extension/bvn_extension_build.py
@@ -6,7 +6,7 @@ from cffi import FFI
 
 ffibuilder = FFI()
 
-header = "int run_bvn(double* flows, int* subsets, int nrevs, int npaps);"
+header = "int run_bvn(int* flows, int* subsets, int nrevs, int npaps, int one_);"
 ffibuilder.cdef(header)
 ffibuilder.set_source("_bvn_extension", # extension name
     header,

--- a/matcher/solvers/randomized_solver.py
+++ b/matcher/solvers/randomized_solver.py
@@ -218,7 +218,7 @@ class RandomizedSolver():
         for i in range(self.num_revs):
             Sbuf[i] = 1
 
-        run_bvn(Fbuf, Sbuf, self.num_paps, self.num_revs)
+        run_bvn(Fbuf, Sbuf, self.num_paps, self.num_revs, self.one)
 
         self.flow_matrix = np.zeros((self.num_paps, self.num_revs))
         for i in range(F.size):

--- a/tests/test_solvers_randomized.py
+++ b/tests/test_solvers_randomized.py
@@ -452,3 +452,23 @@ def test_opt_fraction():
     assert solver.expected_cost == -3
     assert solver.opt_cost == -5
     assert solver.get_fraction_of_opt() == 0.6
+
+
+def test_identical_costs():
+    ''' Test that LP is integral when all costs identical '''
+    S = np.transpose(np.array([
+        [1.0, 1],
+        [1, 1],
+        [1, 1],
+        [1, 1]
+    ]))
+    M = np.zeros(np.shape(S))
+    Q = np.full(np.shape(S), 1.0)
+    solver = RandomizedSolver(
+        [0,0,0,0],
+        [1,1,1,1],
+        [2,2],
+        encoder(-S, M, Q)
+    )
+    for _ in range(1000):
+        check_test_solution(solver, T=1)


### PR DESCRIPTION
Addressing the issue referenced in https://github.com/openreview/openreview-matcher/pull/214#issue-665191901 (wasn't sure how to commit there, happy to do so if it would be better).

The randomized_solver now handles the precision of the fractional assignment by scaling all constraints to integers before running the LP. In case there's somehow another rounding issue of this kind in the future, it should be caught now by additional assertions in Python rather than having the C code hang.