### PR TITLE
Change randomized solver to use minmax solver internally

### DIFF
--- a/matcher/solvers/randomized_solver.py
+++ b/matcher/solvers/randomized_solver.py
@@ -12,7 +12,7 @@ Alternates are also selected probabilistically so that the probability limits
 are maintained even if all alternates are used.
 '''
 
-from .simple_solver import SimpleSolver
+from .minmax_solver import MinMaxSolver
 from .core import SolverException
 from .bvn_extension import run_bvn
 from ortools.linear_solver import pywraplp
@@ -38,6 +38,7 @@ class RandomizedSolver():
         self.num_paps, self.num_revs = self.cost_matrix.shape
         self.allow_zero_score_assignments = allow_zero_score_assignments
         self.logger = logger
+        self.encoder = encoder # for passing cost and constraint matrices to MinMaxSolver
 
         if not self.cost_matrix.any():
             self.cost_matrix = np.random.rand(*encoder.cost_matrix.shape)
@@ -64,11 +65,11 @@ class RandomizedSolver():
         self.opt_cost = None # cost of the optimal deterministic assignment
 
         self.integer_fractional_assignment_matrix = None # actual solution to LP
-        self.one = 10000000 # precision of fractional assignment
+        self.one = 100000 # precision of fractional assignment
 
         self._check_inputs()
-        self.fractional_assignment_solver = self.construct_solver(self.prob_limit_matrix)
-        self.deterministic_assignment_solver = self.construct_solver(np.ones_like(self.prob_limit_matrix))
+        self.fractional_assignment_solver = self.construct_solver(self.prob_limit_matrix, self.one)
+        self.deterministic_assignment_solver = self.construct_solver(np.ones_like(self.prob_limit_matrix), 1)
 
 
     def _check_inputs(self):
@@ -119,42 +120,18 @@ class RandomizedSolver():
 
         self.logger.debug('Finished checking if demand is in range')
 
-    def construct_solver(self, limit_matrix):
-        ''' LP is solved with all probabilities scaled up by self.one. Solution is assumed to be integral. '''
+    def construct_solver(self, limit_matrix, scale):
+        ''' LP is solved with all probabilities scaled up by scale. Solution is assumed to be integral. '''
         self.logger.debug('construct_solver')
-        lp_solver = pywraplp.Solver.CreateSolver('GLOP')
 
-        F = [[None for j in range(self.num_revs)] for i in range(self.num_paps)]
-        for i, j in product(range(self.num_paps), range(self.num_revs)):
-            constraint = self.constraint_matrix[i, j]
-            limit = int(self.one * limit_matrix[i, j])
-            if constraint == 0 and (self.allow_zero_score_assignments or self.cost_matrix[i, j] != 0):
-                # no conflict
-                F[i][j] = lp_solver.NumVar(0, limit, "F[{}][{}]".format(i, j))
-            elif constraint == 1:
-                # assign to paper as much as possible given limits
-                F[i][j] = lp_solver.NumVar(limit, limit, "F[{}][{}]".format(i, j))
-            else:
-                # conflict
-                F[i][j] = lp_solver.NumVar(0, 0, "F[{}][{}]".format(i, j))
-
-        for i in range(self.num_paps):
-            c = lp_solver.Constraint(int(self.one*self.demands[i]), int(self.one*self.demands[i]))
-            for j in range(self.num_revs):
-                c.SetCoefficient(F[i][j], 1)
-
-        for j in range(self.num_revs):
-            c = lp_solver.Constraint(int(self.one*self.minimums[j]), int(self.one*self.maximums[j]))
-            for i in range(self.num_paps):
-                c.SetCoefficient(F[i][j], 1)
-
-        objective = lp_solver.Objective()
-        for i, j in product(range(self.num_paps), range(self.num_revs)):
-            objective.SetCoefficient(F[i][j], self.cost_matrix[i, j])
-        objective.SetMinimization()
+        scaled_minimums = scale * np.array(self.minimums)
+        scaled_maximums = scale * np.array(self.maximums)
+        scaled_demands = scale * np.array(self.demands)
+        scaled_limits = scale * limit_matrix
+        solver = MinMaxSolver(scaled_minimums, scaled_maximums, scaled_demands, self.encoder, self.allow_zero_score_assignments, self.logger, scaled_limits)
 
         self.logger.debug('Finished construct_solver')
-        return lp_solver
+        return solver
 
 
     def solve(self):
@@ -167,45 +144,34 @@ class RandomizedSolver():
 
         self.logger.debug('start fractional_assignment_solver')
 
-        self.expected_cost = 0
-        self.logger.debug('call to Solve()')
-        status = self.fractional_assignment_solver.Solve()
-        self.logger.debug('check optimal')
-        if status == self.fractional_assignment_solver.OPTIMAL:
-            self.logger.debug('status is optimal')
-            self.solved = True
-            self.expected_cost = self.fractional_assignment_solver.Objective().Value() / self.one
-            self.logger.debug('start iterating papers and reviewers')
-            self.integer_fractional_assignment_matrix = np.zeros((self.num_paps, self.num_revs), dtype=np.intc)
-            for i, j in product(range(self.num_paps), range(self.num_revs)):
-                self.logger.debug('before lookup variable: ' + str(i) + ', ' + str(j))
-                actual_value = self.fractional_assignment_solver.LookupVariable("F[{}][{}]".format(i, j)).solution_value()
-                self.logger.debug('actual_value: ' + str(actual_value))
-                if np.round(actual_value) - actual_value > 1e-5:
-                    self.logger.debug('LP solution not integral at ' + str(i) + ',' + str(j) + ' with value of ' + str(actual_value))
-                self.integer_fractional_assignment_matrix[i, j] = np.round(actual_value) # assumes that round does not ruin paper load integrality
+        result_matrix = self.fractional_assignment_solver.solve()
+        self.solved = self.fractional_assignment_solver.solved
+        self.expected_cost = self.fractional_assignment_solver.cost / self.one
 
-            if not np.all(np.sum(self.integer_fractional_assignment_matrix, axis=1) % self.one == 0):
-                self.logger.debug('Paper loads rounded')
-                self.solved = False
-                return
+        self.logger.debug('start iterating papers and reviewers')
+        self.integer_fractional_assignment_matrix = np.zeros((self.num_paps, self.num_revs), dtype=np.intc)
+        for i, j in product(range(self.num_paps), range(self.num_revs)):
+            actual_value = result_matrix[i, j]
+            if np.round(actual_value) - actual_value > 1e-5:
+                self.logger.debug('LP solution not integral at ' + str(i) + ',' + str(j) + ' with value of ' + str(actual_value))
+            self.integer_fractional_assignment_matrix[i, j] = np.round(actual_value) # assumes that round does not ruin paper load integrality
+        if not self.solved:
+            self.logger.debug('fractional_assignment solving failed')
+            return
 
-            self.fractional_assignment_matrix = self.integer_fractional_assignment_matrix / self.one
-        else:
-            self.logger.debug("Solver status: {}".format(status))
+        if not np.all(np.sum(self.integer_fractional_assignment_matrix, axis=1) % self.one == 0):
+            self.logger.debug('Paper loads rounded')
             self.solved = False
             return
 
+        self.fractional_assignment_matrix = self.integer_fractional_assignment_matrix / self.one
+
         self.logger.debug('start deterministic_assignment_solver')
 
-        self.opt_cost = 0
-        status = self.deterministic_assignment_solver.Solve()
-        if status == self.deterministic_assignment_solver.OPTIMAL:
-            self.opt_solved = True
-            self.opt_cost = self.deterministic_assignment_solver.Objective().Value() / self.one
-        else:
-            self.logger.debug("Deterministic solver status: {}".format(status))
-            self.opt_solved = False
+        result_matrix = self.deterministic_assignment_solver.solve()
+        self.opt_solved = self.deterministic_assignment_solver.solved
+        self.opt_cost = self.deterministic_assignment_solver.cost
+
 
         self.logger.debug('set alternate_probability_matrix')
         # set alternate probability to guarantee that

--- a/matcher/solvers/randomized_solver.py
+++ b/matcher/solvers/randomized_solver.py
@@ -147,6 +147,9 @@ class RandomizedSolver():
         result_matrix = self.fractional_assignment_solver.solve()
         self.solved = self.fractional_assignment_solver.solved
         self.expected_cost = self.fractional_assignment_solver.cost / self.one
+        if not self.solved:
+            self.logger.debug('fractional_assignment solving failed')
+            return
 
         self.logger.debug('start iterating papers and reviewers')
         self.integer_fractional_assignment_matrix = np.zeros((self.num_paps, self.num_revs), dtype=np.intc)
@@ -155,10 +158,6 @@ class RandomizedSolver():
             if np.round(actual_value) - actual_value > 1e-5:
                 self.logger.debug('LP solution not integral at ' + str(i) + ',' + str(j) + ' with value of ' + str(actual_value))
             self.integer_fractional_assignment_matrix[i, j] = np.round(actual_value) # assumes that round does not ruin paper load integrality
-        if not self.solved:
-            self.logger.debug('fractional_assignment solving failed')
-            return
-
         if not np.all(np.sum(self.integer_fractional_assignment_matrix, axis=1) % self.one == 0):
             self.logger.debug('Paper loads rounded')
             self.solved = False

--- a/tests/test_solvers_randomized.py
+++ b/tests/test_solvers_randomized.py
@@ -3,7 +3,12 @@ from collections import namedtuple
 import numpy as np
 from matcher.solvers import SolverException, RandomizedSolver
 
-encoder = namedtuple('Encoder', ['cost_matrix', 'constraint_matrix', 'prob_limit_matrix'])
+cost_scale = 1000
+class encoder:
+    def __init__(self, cost, constraint, prob_limit):
+        self.cost_matrix = cost * cost_scale
+        self.constraint_matrix = constraint
+        self.prob_limit_matrix = prob_limit
 
 
 def check_sampled_solution(solver):
@@ -293,10 +298,10 @@ def test_solution_optimal_no_limit():
     solver.solve()
 
     assert np.all(solver.fractional_assignment_matrix == solution) and np.all(solver.flow_matrix == solution)
-    assert solver.expected_cost == -3.2 and solver.cost == -3.2
+    assert solver.expected_cost == (cost_scale * -3.2) and solver.cost == (cost_scale * -3.2)
     solver.sample_assignment() # should not change since assignment is deterministic
     assert np.all(solver.fractional_assignment_matrix == solution) and np.all(solver.flow_matrix == solution)
-    assert solver.expected_cost == -3.2 and solver.cost == -3.2
+    assert solver.expected_cost == (cost_scale * -3.2) and solver.cost == (cost_scale * -3.2)
 
 
 def test_constraints():
@@ -416,8 +421,8 @@ def test_opt_fraction():
 
     solver.solve()
     assert solver.solved and solver.opt_solved
-    assert solver.expected_cost == -2.5
-    assert solver.opt_cost == -5
+    assert solver.expected_cost == (cost_scale * -2.5)
+    assert solver.opt_cost == (cost_scale * -5)
     assert solver.get_fraction_of_opt() == 0.5
 
     S = np.eye(5)
@@ -434,8 +439,8 @@ def test_opt_fraction():
 
     solver.solve()
     assert solver.solved and solver.opt_solved
-    assert solver.expected_cost == -5
-    assert solver.opt_cost == -5
+    assert solver.expected_cost == (cost_scale * -5)
+    assert solver.opt_cost == (cost_scale * -5)
     assert solver.get_fraction_of_opt() == 1
 
     Q = np.full(np.shape(S), 0.3)
@@ -449,8 +454,8 @@ def test_opt_fraction():
 
     solver.solve()
     assert solver.solved and solver.opt_solved
-    assert solver.expected_cost == -3
-    assert solver.opt_cost == -5
+    assert solver.expected_cost == (cost_scale * -3)
+    assert solver.opt_cost == (cost_scale * -5)
     assert solver.get_fraction_of_opt() == 0.6
 
 


### PR DESCRIPTION
Avoid using the LP solver and just use minmax solver for any assignments (probably cleaner and faster anyway). Required some small modifications to minmax and simple solver to allow for assigning "fractional" reviewers when specified.