### PR TITLE
Change compilation of extension

### DIFF
--- a/matcher/solvers/bvn_extension/bvn_extension_build.py
+++ b/matcher/solvers/bvn_extension/bvn_extension_build.py
@@ -12,6 +12,4 @@ ffibuilder.set_source("_bvn_extension", # extension name
     header,
     sources=['matcher/solvers/bvn_extension/bvn.c'],
     libraries=['m'])  # link with the math library
-
-if __name__ == "__main__":
-    ffibuilder.compile(verbose=True)
+ffibuilder.compile(verbose=True)


### PR DESCRIPTION
I'm not sure if this is the most proper way to set up the compilation, but according to my testing it now rebuilds the C code whenever there's a change (where it wasn't doing it before). After this change, `pip install -e .` should rebuild everything with the correct/new C code.