### PR TITLE
Solver - Reviewer Round Robin

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Basic implementation using the Minimum Cost function implemented in the Google [
 
 ### FairFlow Solver
 
-Fairlfow solver tries to more fairly assign reviewers to papers in a way that each paper has at least some minimum affinity with the reviewers to which it is assigned.
+Fairflow solver tries to more fairly assign reviewers to papers in a way that each paper has at least some minimum affinity with the reviewers to which it is assigned.
 
 For more information, see [this paper](https://arxiv.org/abs/1905.11924v1)
 
@@ -52,6 +52,12 @@ The randomized solver (`--solver Randomized` on the command line) implements a r
 The solver returns a deterministic assignment which was sampled from this randomized assignment. The sampling algorithm is implemented in `matcher/solvers/bvn_extension`.
 
 For more information, see [this paper](https://arxiv.org/abs/2006.16437).
+
+### Reviewer Round Robin
+
+Greedy reviewer round robin (`--solver GRRR` on the command line) attempts to create an allocation of reviewers that is fair according to the weighted envy-free up to 1 item (WEF1) criterion. Papers pick reviewers one-by-one, with priority given to the papers with the lowest ratio of allocation size to demand. By default, ties in priority are resolved in a randomly selected, fixed order. If a sample size greater than 1 is specified, the algorithm will perform a greedy search for an optimal tie-breaking order (using the specified number of samples at each step).
+
+For more information about the WEF1 fairness criterion, see [this paper](https://ifaamas.org/Proceedings/aamas2020/pdfs/p231.pdf), and for more information about the greedy search procedure, see [this paper](https://arxiv.org/abs/2108.02126).
 
 ## Running the Server
 The server is implemented in Flask and uses Celery to manage the matching tasks asynchronously and can be started from the command line:

--- a/matcher/solvers/__init__.py
+++ b/matcher/solvers/__init__.py
@@ -5,3 +5,4 @@ from .minmax_solver import MinMaxSolver
 from .simple_solver import SimpleSolver
 from .randomized_solver import RandomizedSolver
 from .fairflow import FairFlow
+from .grrr import GRRR

--- a/matcher/solvers/grrr.py
+++ b/matcher/solvers/grrr.py
@@ -1,0 +1,276 @@
+from collections import defaultdict
+from ortools.graph import pywrapgraph
+import numpy as np
+import random
+import uuid
+import time
+from .core import SolverException
+import logging
+
+
+class GRRR(object):
+    """
+    Assign reviewers using the Greedy Reviewer Round-Robin algorithm
+    from I Will Have Order! Optimizing Orders for Fair Reviewer Assignment
+    (https://arxiv.org/abs/2108.02126). This algorithm outputs an approximately
+    optimal assignment that satisfies the envy-free up to 1 item (EF1) criterion.
+
+    Reviewer Round-Robin (RRR) puts papers in a random order, then allows each
+    paper to choose its favorite reviewer one-by-one in order. Some constraints
+    apply to the selection process - most importantly, no paper can choose a
+    reviewer that would cause an EF1 violation. Greedy RRR (GRRR) approximately
+    finds the order of papers that produces the highest overall welfare when input
+    to RRR.
+    """
+
+    def __init__(self, minimums, maximums, demands, encoder, allow_zero_score_assignments=False, solution=None,
+                 logger=logging.getLogger(__name__)):
+        """
+        Initialize a GRRR matcher
+
+        :param minimums: a list of integers specifying the minimum number of papers for each reviewer.
+        :param maximums: a list of integers specifying the maximum number of papers for each reviewer.
+        :param demands: a list of integers specifying the number of reviews required per paper.
+        :param encoder: an Encoder class object used to get affinity and constraint matrices.
+        :param allow_zero_score_assignments: bool to allow pairs with zero affinity in the solution.
+            unknown matching scores default to 0. set to True to allow zero (unknown) affinity in solution.
+        :param solution: a matrix of assignments (same shape as encoder.affinity_matrix)
+
+        :return: initialized makespan matcher.
+        """
+        self.logger = logger
+        self.logger.debug('Init GRRR')
+        self.constraint_matrix = encoder.constraint_matrix.transpose()
+        affinity_matrix = encoder.aggregate_score_matrix.transpose()
+
+        """
+        The number of papers to consider in each step of _select_ordering().
+        Higher sample_size can improve objective score at the cost of increased runtime.
+        """
+        self.sample_size = 10
+
+        self.maximums = maximums
+        self.minimums = minimums
+        self.demands = demands
+
+        # make sure that all weights are positive:
+        self.affinity_matrix = affinity_matrix.copy()
+        if not self.affinity_matrix.any():
+            self.affinity_matrix = np.random.rand(*affinity_matrix.shape)
+
+        self.best_revs = np.argsort(-1 * self.affinity_matrix, axis=0)
+
+        self.orig_affinities = self.affinity_matrix.copy()
+
+        self.num_reviewers = np.size(self.affinity_matrix, axis=0)
+        self.num_papers = np.size(self.affinity_matrix, axis=1)
+
+        self.id = uuid.uuid4()
+        self.solution = solution if solution else np.zeros((self.num_reviewers, self.num_papers))
+        assert (self.affinity_matrix.shape == self.solution.shape)
+        self.max_affinities = np.max(self.affinity_matrix)
+
+        self.solved = False
+        self.logger.debug('End Init GRRR')
+
+    def _validate_input_range(self):
+        """Validate if demand is in the range of min supply and max supply,
+        and forbids currently unsupported settings."""
+        self.logger.debug('Checking if demand is in range')
+
+        min_supply = sum(self.minimums)
+        max_supply = sum(self.maximums)
+        demand = sum(self.demands)
+
+        self.logger.debug(
+            'Total demand is ({}), min review supply is ({}), and max review supply is ({})'.format(demand, min_supply,
+                                                                                                    max_supply))
+
+        if np.any(self.minimums):
+            raise SolverException(
+                'GRRR does not currently support minimum values for number of papers per reviewer')
+
+        if np.min(self.demands) < np.max(self.demands):
+            raise SolverException(
+                'GRRR does not currently support different demands for each paper')
+
+        if demand > max_supply or demand < min_supply:
+            raise SolverException('Total demand ({}) is out of range when max review '
+                                  'supply is ({})'.format(demand, min_supply, max_supply))
+
+        self.logger.debug('Finished checking graph inputs')
+
+    def objective_val(self):
+        """Get the objective value of the RAP."""
+        return np.sum(self.sol_as_mat() * self.orig_affinities)
+
+    def sol_as_mat(self):
+        if self.solved:
+            return self.solution
+        else:
+            raise SolverException(
+                'You must have solved for an ordering and run round-robin before calling this function')
+
+    def is_safe_choice(self, r, p, order_idx_map, matrix_alloc, papers_who_tried_revs, round_num, first_reviewer):
+        """Ensure that we can assign reviewer r to paper p without breaking envy-freeness up to 1 item.
+
+        If we are assigning the first reviewer to each paper, then EF1 cannot be broken. Otherwise,
+        we must check any paper which has taken or tried to take r in the past. If that paper comes before
+        p in the round-robin ordering, then make sure it values its own reviewers over p's current reviewers and r.
+        If that paper comes after p, make sure it values its own reviewers over p's current reviewers, minus p's
+        first-choice reviewer, plus r.
+
+        See the paper I Will Have Order! Optimizing Orders for Reviewer Assignment for more details.
+
+        Args:
+            r - (int) the id of the reviewer we want to add
+            p - (int) the id of the paper to which we are adding r
+            order_idx_map - (dict) maps papers to their index in the round-robin order
+            matrix_alloc - (2d numpy array) the current allocation
+            papers_who_tried_revs - (dict) maps each reviewer to a list of papers that have tried to select it
+            round_num - (int) the round of round-robin
+            first_reviewer - (dict) maps each paper to the reviewer it chose in round 0
+
+        Returns:
+            True if r can be assigned to p without violating EF1, False otherwise.
+        """
+        if round_num == 0 or not len(papers_who_tried_revs[r]):
+            return True
+        p_idx = order_idx_map[p]
+
+        # Construct the allocations we'll use for comparison
+        p_alloc_orig = matrix_alloc[:, p]
+        p_alloc_proposed = p_alloc_orig.copy()
+        p_alloc_proposed[r] = 1
+        p_alloc_proposed_reduced = p_alloc_proposed.copy()
+        p_alloc_proposed_reduced[first_reviewer[p]] = 0
+
+        for q in papers_who_tried_revs[r]:
+            if q != p:
+                # Check that they will not envy a if we add r to a.
+                _p = p_alloc_proposed if (order_idx_map[q] < p_idx) else p_alloc_proposed_reduced
+                q_value_for_p_proposed = np.sum(_p * self.affinity_matrix[:, q])
+
+                q_value_for_q = np.sum(matrix_alloc[:, q] * self.affinity_matrix[:, q])
+                if q_value_for_p_proposed > q_value_for_q \
+                        and not np.isclose(q_value_for_p_proposed, q_value_for_q):
+                    return False
+        return True
+
+    def safe_rr(self, ordering):
+        """Compute round-robin assignment with the papers in this ordering.
+
+        Papers select their favorite remaining reviewer in each round,
+        subject to constraints - papers cannot pick a reviewer which would
+        cause another paper to envy them up to more than 1 reviewer, and they
+        cannot pick a reviewer which is forbidden by the predefined constraint_matrix.
+
+        Args:
+            ordering - (list) ordered list of a subset of papers for round-robin
+
+        Returns:
+            A 2d numpy array with an EF1 partial allocation to the papers in ordering.
+            The array has the same shape as self.affinity_matrix, with a 1 in the i, j
+            entry when reviewer i is assigned to paper j (and 0 otherwise).
+        """
+        matrix_alloc = np.zeros(self.affinity_matrix.shape, dtype=np.bool)
+        maximums_copy = self.maximums.copy()
+
+        papers_who_tried_revs = defaultdict(list)
+        first_reviewer = {}
+
+        order_idx_map = {p: idx for idx, p in enumerate(ordering)}
+
+        for round_num in range(self.demands[ordering[0]]):
+            for a in ordering:
+                new_assn = False
+                for r in self.best_revs[:, a]:
+                    if maximums_copy[r] > 0 \
+                            and r not in np.where(matrix_alloc[:, a])[0] \
+                            and self.constraint_matrix[r, a] == 0:
+                        if self.is_safe_choice(r, a, order_idx_map, matrix_alloc,
+                                               papers_who_tried_revs, round_num, first_reviewer):
+                            maximums_copy[r] -= 1
+                            matrix_alloc[r, a] = 1
+                            if round_num == 0:
+                                first_reviewer[a] = r
+                            papers_who_tried_revs[r].append(a)
+                            new_assn = True
+                            break
+                        else:
+                            papers_who_tried_revs[r].append(a)
+                if not new_assn:
+                    raise SolverException(
+                        'GRRR was unable to find an EF1 allocation satisfying all papers\' demands')
+        return matrix_alloc
+
+    def _compute_usw(self, ordering):
+        """Compute the utilitarian social welfare (USW) for the assignment produced
+        by running round-robin assignment with the papers in this ordering.
+
+        Args:
+            ordering - (list) ordered list of a subset of papers for round-robin
+
+        Returns:
+            USW, as a float.
+        """
+        matrix_alloc = self.safe_rr(ordering)
+        return np.sum(matrix_alloc * self.affinity_matrix)
+
+    def _select_ordering(self):
+        """Greedily select a paper ordering for round-robin.
+
+        At each step, we consider adding some subset of the remaining papers to the
+        end of the current ordering. We add the paper which results in the largest
+        USW of all papers in the subset.
+
+        Args:
+            None
+
+        Returns:
+            A list of all papers in the greedily-selected order.
+        """
+        m, n = self.affinity_matrix.shape
+
+        available_agents = set(range(n))
+        ordering = []
+
+        curr_usw = 0
+        mg_upper_bound = np.max(self.demands) * np.max(self.affinity_matrix)
+
+        while len(ordering) < n:
+            next_agent = None
+            best_usw = -np.inf
+
+            sample_size = min(self.sample_size, len(available_agents))
+            sorted_agents = sorted(random.sample(available_agents, sample_size))
+            for a in sorted_agents:
+                usw = self._compute_usw(ordering + [a])
+                if usw > best_usw:
+                    best_usw = usw
+                    next_agent = a
+                if best_usw - curr_usw == mg_upper_bound:
+                    break
+
+            curr_usw = best_usw
+            ordering.append(next_agent)
+            available_agents.remove(next_agent)
+        return ordering
+
+    def solve(self):
+        """Find an approximately optimal order and run round-robin assignment.
+
+        Args:
+            None
+
+        Returns:
+            The solution as a matrix.
+        """
+
+        self._validate_input_range()
+
+        ordering = self._select_ordering()
+        self.solution = self.safe_rr(ordering)
+
+        self.solved = True
+        return self.sol_as_mat().transpose()

--- a/matcher/solvers/grrr.py
+++ b/matcher/solvers/grrr.py
@@ -10,21 +10,24 @@ import logging
 
 class GRRR(object):
     """
-    Assign reviewers using the Greedy Reviewer Round-Robin algorithm
+    Assign reviewers using a modified version of the Greedy Reviewer Round-Robin algorithm
     from I Will Have Order! Optimizing Orders for Fair Reviewer Assignment
     (https://arxiv.org/abs/2108.02126). This algorithm outputs an approximately
-    optimal assignment that satisfies the envy-free up to 1 item (EF1) criterion.
+    optimal assignment that satisfies the weighted envy-free up to 1 item (WEF1) criterion.
 
-    Reviewer Round-Robin (RRR) puts papers in a random order, then allows each
-    paper to choose its favorite reviewer one-by-one in order. Some constraints
+    Reviewer Round-Robin (RRR) attempts to create an allocation of reviewers that is fair
+    according to the weighted envy-free up to 1 item (WEF1) criterion. Papers pick reviewers
+    one-by-one, with priority given to the papers with the lowest ratio of allocation size to demand.
+    By default, ties in priority are resolved in a randomly selected, fixed order.
+    If a sample_size greater than 1 is specified, the algorithm will perform a greedy search for an
+    optimal tie-breaking order (using the specified number of samples at each step). Some constraints
     apply to the selection process - most importantly, no paper can choose a
-    reviewer that would cause an EF1 violation. Greedy RRR (GRRR) approximately
-    finds the order of papers that produces the highest overall welfare when input
-    to RRR.
+    reviewer that would cause a WEF1 violation. If this procedure fails to discover a WEF1 allocation,
+    we try the picking sequence again, allowing WEF1 violations during the process. 
     """
 
     def __init__(self, minimums, maximums, demands, encoder, allow_zero_score_assignments=False, solution=None,
-                 logger=logging.getLogger(__name__)):
+                 sample_size=1, logger=logging.getLogger(__name__)):
         """
         Initialize a GRRR matcher
 
@@ -39,21 +42,20 @@ class GRRR(object):
         :return: initialized makespan matcher.
         """
         self.logger = logger
+        self.allow_zero_score_assignments = allow_zero_score_assignments
         self.logger.debug('Init GRRR')
         self.constraint_matrix = encoder.constraint_matrix.transpose()
         affinity_matrix = encoder.aggregate_score_matrix.transpose()
 
-        """
-        The number of papers to consider in each step of _select_ordering().
-        Higher sample_size can improve objective score at the cost of increased runtime.
-        """
-        self.sample_size = 10
 
-        self.maximums = maximums
-        self.minimums = minimums
-        self.demands = demands
+        # The number of papers to consider in each step of _select_ordering().
+        # Higher sample_size can improve objective score at the cost of increased runtime.
+        self.sample_size = sample_size
 
-        # make sure that all weights are positive:
+        self.maximums = np.array(maximums)
+        self.minimums = np.array(minimums)
+        self.demands = np.array(demands)
+
         self.affinity_matrix = affinity_matrix.copy()
         if not self.affinity_matrix.any():
             self.affinity_matrix = np.random.rand(*affinity_matrix.shape)
@@ -65,10 +67,27 @@ class GRRR(object):
         self.num_reviewers = np.size(self.affinity_matrix, axis=0)
         self.num_papers = np.size(self.affinity_matrix, axis=1)
 
+        if not self.allow_zero_score_assignments:
+            # Find reviewers with no non-zero affinity edges after constraints are applied and remove their load_lb
+            bad_affinity_reviewers = np.where(
+                np.all(
+                    (self.affinity_matrix * (self.constraint_matrix == 0))
+                    == 0,
+                    axis=1,
+                )
+            )[0]
+            logging.debug(
+                "Setting minimum load for {} reviewers to 0 "
+                "because they do not have known affinity with any paper".format(
+                    len(bad_affinity_reviewers)
+                )
+            )
+            for rev_id in bad_affinity_reviewers:
+                self.minimums[rev_id] = 0
+
         self.id = uuid.uuid4()
         self.solution = solution if solution else np.zeros((self.num_reviewers, self.num_papers))
         assert (self.affinity_matrix.shape == self.solution.shape)
-        self.max_affinities = np.max(self.affinity_matrix)
 
         self.solved = False
         self.logger.debug('End Init GRRR')
@@ -78,27 +97,19 @@ class GRRR(object):
         and forbids currently unsupported settings."""
         self.logger.debug('Checking if demand is in range')
 
-        min_supply = sum(self.minimums)
-        max_supply = sum(self.maximums)
-        demand = sum(self.demands)
+        min_supply = np.sum(self.minimums)
+        max_supply = np.sum(self.maximums)
+        demand = np.sum(self.demands)
 
         self.logger.debug(
             'Total demand is ({}), min review supply is ({}), and max review supply is ({})'.format(demand, min_supply,
                                                                                                     max_supply))
 
-        if np.any(self.minimums):
-            raise SolverException(
-                'GRRR does not currently support minimum values for number of papers per reviewer')
-
-        if np.min(self.demands) < np.max(self.demands):
-            raise SolverException(
-                'GRRR does not currently support different demands for each paper')
-
         if demand > max_supply or demand < min_supply:
-            raise SolverException('Total demand ({}) is out of range when max review '
-                                  'supply is ({})'.format(demand, min_supply, max_supply))
+            raise SolverException('Total demand ({}) is out of range when min review supply is ({}) '
+                                  'and max review supply is ({})'.format(demand, min_supply, max_supply))
 
-        self.logger.debug('Finished checking graph inputs')
+        self.logger.debug('Finished checking input ranges')
 
     def objective_val(self):
         """Get the objective value of the RAP."""
@@ -109,18 +120,20 @@ class GRRR(object):
             return self.solution
         else:
             raise SolverException(
-                'You must have solved for an ordering and run round-robin before calling this function')
+                'You must have executed solve() before calling this function')
 
-    def is_safe_choice(self, r, p, order_idx_map, matrix_alloc, papers_who_tried_revs, round_num, first_reviewer):
-        """Ensure that we can assign reviewer r to paper p without breaking envy-freeness up to 1 item.
+    def is_safe_choice(self, r, p, order_idx_map, matrix_alloc, papers_who_tried_revs, first_reviewer):
+        """Ensure that we can assign reviewer r to paper p without breaking weighted envy-freeness up to 1 item.
 
-        If we are assigning the first reviewer to each paper, then EF1 cannot be broken. Otherwise,
+        If we are assigning the first reviewer to each paper, then WEF1 cannot be broken. Otherwise,
         we must check any paper which has taken or tried to take r in the past. If that paper comes before
         p in the round-robin ordering, then make sure it values its own reviewers over p's current reviewers and r.
         If that paper comes after p, make sure it values its own reviewers over p's current reviewers, minus p's
-        first-choice reviewer, plus r.
+        first-choice reviewer, plus r. Every value comparison is weighted, to ensure Weighted EF1.
 
-        See the paper I Will Have Order! Optimizing Orders for Reviewer Assignment for more details.
+        See the papers I Will Have Order! Optimizing Orders for Reviewer Assignment by Payan and Zick 2021
+        for more on envy-free reviewer assignment and
+        Weighted Envy-Freeness in Indivisible Item Allocation by Chakraborty et al. 2020 for more on WEF1.
 
         Args:
             r - (int) the id of the reviewer we want to add
@@ -128,13 +141,12 @@ class GRRR(object):
             order_idx_map - (dict) maps papers to their index in the round-robin order
             matrix_alloc - (2d numpy array) the current allocation
             papers_who_tried_revs - (dict) maps each reviewer to a list of papers that have tried to select it
-            round_num - (int) the round of round-robin
             first_reviewer - (dict) maps each paper to the reviewer it chose in round 0
 
         Returns:
-            True if r can be assigned to p without violating EF1, False otherwise.
+            True if r can be assigned to p without violating WEF1, False otherwise.
         """
-        if round_num == 0 or not len(papers_who_tried_revs[r]):
+        if p not in first_reviewer or not len(papers_who_tried_revs[r]):
             return True
         p_idx = order_idx_map[p]
 
@@ -149,16 +161,97 @@ class GRRR(object):
             if q != p:
                 # Check that they will not envy a if we add r to a.
                 _p = p_alloc_proposed if (order_idx_map[q] < p_idx) else p_alloc_proposed_reduced
-                q_value_for_p_proposed = np.sum(_p * self.affinity_matrix[:, q])
 
-                q_value_for_q = np.sum(matrix_alloc[:, q] * self.affinity_matrix[:, q])
-                if q_value_for_p_proposed > q_value_for_q \
+                q_value_for_p_proposed = np.sum(_p * self.affinity_matrix[:, q]) / self.demands[p]
+                q_value_for_q = np.sum(matrix_alloc[:, q] * self.affinity_matrix[:, q]) / self.demands[q]
+
+                if q_value_for_q < q_value_for_p_proposed \
                         and not np.isclose(q_value_for_p_proposed, q_value_for_q):
                     return False
         return True
 
-    def safe_rr(self, ordering):
+    def _restrict_if_necessary(self, reviewers_remaining, matrix_alloc, paper_list):
+        """Determine the number of papers we can still assign to each reviewer
+
+        If we have exactly enough remaining reviewer slots to satisfy reviewer
+        minima, then we set the remaining reviewers to be exactly the reviewers
+        that need their minima satisfied.
+
+        Args:
+            reviewers_remaining - (1d numpy array) maximum number of papers each reviewer can
+                still be assigned
+            matrix_alloc - (2d numpy array) the assignment of reviewers to papers (papers are the rows)
+            paper_list - (list) a subset of papers that we are currently assigning to
+
+        Returns:
+            New reviewers_remaining - either the same as the input if we have enough papers to satisfy
+            reviewer minima, or the exact assignments required to meet minima otherwise.
+        """
+        remaining_demand = np.sum(self.demands[paper_list]) - np.sum(matrix_alloc)
+        required_for_min = self.minimums - np.sum(matrix_alloc, axis=1)
+        required_for_min[required_for_min < 0] = 0
+        return required_for_min if np.sum(required_for_min) >= remaining_demand else reviewers_remaining
+
+    def _select_next_paper(self, matrix_alloc, order_idx_map):
+        """Select the next paper to pick a reviewer
+
+        Each paper i has priority t_i/w_i, where t_i is the number of reviewers already
+        assigned to paper i, and w_i is the total demand of paper i. The
+        paper with lowest priority is chosen, with ties broken by the given ordering.
+        For rationale, please see:
+        Weighted Envy-Freeness in Indivisible Item Allocation by Chakraborty et al. 2020.
+
+        Args:
+            matrix_alloc - (2d numpy array) the assignment of reviewers to papers (papers are the columns)
+            order_idx_map - (dict) a map from (some of) the papers to their positions in an order,
+                used to break ties in priority
+
+        Returns:
+            The index of the next paper to pick a reviewer
+        """
+        priorities = np.sum(matrix_alloc, axis=0) / self.demands
+        return sorted(order_idx_map.items(), key=lambda x: (priorities[x[0]], x[1]))[0][0]
+
+    def rr(self, ordering):
         """Compute round-robin assignment with the papers in this ordering.
+
+        Papers select their favorite remaining reviewer in each round,
+        subject only to constraints in the constraint_matrix.
+
+        Args:
+            ordering - (list) ordered list of a subset of papers for round-robin
+
+        Returns:
+            A 2d numpy array with a partial allocation to the papers in ordering.
+            The array has the same shape as self.affinity_matrix, with a 1 in the i, j
+            entry when reviewer i is assigned to paper j (and 0 otherwise).
+        """
+        matrix_alloc = np.zeros(self.affinity_matrix.shape, dtype=bool)
+        maximums_copy = self.maximums.copy()
+
+        order_idx_map = {p: idx for idx, p in enumerate(ordering)}
+
+        while np.sum(matrix_alloc) < np.sum(self.demands[ordering]):
+            maximums_copy = self._restrict_if_necessary(maximums_copy, matrix_alloc, ordering)
+            a = self._select_next_paper(matrix_alloc, order_idx_map)
+
+            new_assn = False
+            for r in self.best_revs[:, a]:
+                if maximums_copy[r] > 0 \
+                        and r not in np.where(matrix_alloc[:, a])[0] \
+                        and self.constraint_matrix[r, a] == 0 \
+                        and (self.allow_zero_score_assignments or self.affinity_matrix[r, a]):
+
+                    maximums_copy[r] -= 1
+                    matrix_alloc[r, a] = 1
+                    new_assn = True
+                    break
+            if not new_assn:
+                return None
+        return matrix_alloc
+
+    def safe_rr(self, ordering):
+        """Compute round-robin assignment with the papers in this ordering, with safeguards to ensure WEF1.
 
         Papers select their favorite remaining reviewer in each round,
         subject to constraints - papers cannot pick a reviewer which would
@@ -169,11 +262,11 @@ class GRRR(object):
             ordering - (list) ordered list of a subset of papers for round-robin
 
         Returns:
-            A 2d numpy array with an EF1 partial allocation to the papers in ordering.
+            A 2d numpy array with a WEF1 partial allocation to the papers in ordering.
             The array has the same shape as self.affinity_matrix, with a 1 in the i, j
             entry when reviewer i is assigned to paper j (and 0 otherwise).
         """
-        matrix_alloc = np.zeros(self.affinity_matrix.shape, dtype=np.bool)
+        matrix_alloc = np.zeros(self.affinity_matrix.shape, dtype=bool)
         maximums_copy = self.maximums.copy()
 
         papers_who_tried_revs = defaultdict(list)
@@ -181,27 +274,28 @@ class GRRR(object):
 
         order_idx_map = {p: idx for idx, p in enumerate(ordering)}
 
-        for round_num in range(self.demands[ordering[0]]):
-            for a in ordering:
-                new_assn = False
-                for r in self.best_revs[:, a]:
-                    if maximums_copy[r] > 0 \
-                            and r not in np.where(matrix_alloc[:, a])[0] \
-                            and self.constraint_matrix[r, a] == 0:
-                        if self.is_safe_choice(r, a, order_idx_map, matrix_alloc,
-                                               papers_who_tried_revs, round_num, first_reviewer):
-                            maximums_copy[r] -= 1
-                            matrix_alloc[r, a] = 1
-                            if round_num == 0:
-                                first_reviewer[a] = r
-                            papers_who_tried_revs[r].append(a)
-                            new_assn = True
-                            break
-                        else:
-                            papers_who_tried_revs[r].append(a)
-                if not new_assn:
-                    raise SolverException(
-                        'GRRR was unable to find an EF1 allocation satisfying all papers\' demands')
+        while np.sum(matrix_alloc) < np.sum(self.demands[ordering]):
+            maximums_copy = self._restrict_if_necessary(maximums_copy, matrix_alloc, ordering)
+            a = self._select_next_paper(matrix_alloc, order_idx_map)
+
+            new_assn = False
+            for r in self.best_revs[:, a]:
+                if maximums_copy[r] > 0 \
+                        and r not in np.where(matrix_alloc[:, a])[0] \
+                        and self.constraint_matrix[r, a] == 0 \
+                        and (self.allow_zero_score_assignments or self.affinity_matrix[r, a]):
+                    if self.is_safe_choice(r, a, order_idx_map, matrix_alloc, papers_who_tried_revs, first_reviewer):
+                        maximums_copy[r] -= 1
+                        matrix_alloc[r, a] = 1
+                        if a not in first_reviewer:
+                            first_reviewer[a] = r
+                        papers_who_tried_revs[r].append(a)
+                        new_assn = True
+                        break
+                    else:
+                        papers_who_tried_revs[r].append(a)
+            if not new_assn:
+                return None
         return matrix_alloc
 
     def _compute_usw(self, ordering):
@@ -215,14 +309,14 @@ class GRRR(object):
             USW, as a float.
         """
         matrix_alloc = self.safe_rr(ordering)
-        return np.sum(matrix_alloc * self.affinity_matrix)
+        return np.sum(matrix_alloc * self.affinity_matrix) if matrix_alloc is not None else None
 
     def _select_ordering(self):
         """Greedily select a paper ordering for round-robin.
 
         At each step, we consider adding some subset of the remaining papers to the
         end of the current ordering. We add the paper which results in the largest
-        USW of all papers in the subset.
+        USW of all papers in the subset. If order selection fails, we default to a random ordering.
 
         Args:
             None
@@ -236,25 +330,33 @@ class GRRR(object):
         ordering = []
 
         curr_usw = 0
-        mg_upper_bound = np.max(self.demands) * np.max(self.affinity_matrix)
+        mg_upper_bound = np.max(self.demands) * np.max(self.affinity_matrix * (1 - self.constraint_matrix))
+
+        if self.sample_size == 1:
+            return sorted(list(range(n)), key=lambda x: random.random())
 
         while len(ordering) < n:
             next_agent = None
             best_usw = -np.inf
 
             sample_size = min(self.sample_size, len(available_agents))
-            sorted_agents = sorted(random.sample(available_agents, sample_size))
+            sorted_agents = sorted(random.sample(list(available_agents), sample_size))
             for a in sorted_agents:
                 usw = self._compute_usw(ordering + [a])
-                if usw > best_usw:
-                    best_usw = usw
-                    next_agent = a
-                if best_usw - curr_usw == mg_upper_bound:
-                    break
+                if usw is not None:
+                    if usw > best_usw:
+                        best_usw = usw
+                        next_agent = a
+                    if best_usw - curr_usw == mg_upper_bound:
+                        break
 
-            curr_usw = best_usw
-            ordering.append(next_agent)
-            available_agents.remove(next_agent)
+            if next_agent is not None:
+                curr_usw = best_usw
+                ordering.append(next_agent)
+                available_agents.remove(next_agent)
+            else:
+                # If unable to return an optimized order, return a random order
+                return sorted(list(range(n)), key=lambda x: random.random())
         return ordering
 
     def solve(self):
@@ -269,8 +371,49 @@ class GRRR(object):
 
         self._validate_input_range()
 
+        improper_papers = np.any(self.demands == 0)
+        if improper_papers:
+            proper_papers = np.where(self.demands > 0)[0]
+
+            saved_demands = np.copy(self.demands)
+            saved_constraint_matrix = np.copy(self.constraint_matrix)
+            saved_affinity_matrix = np.copy(self.affinity_matrix)
+
+            self.demands = self.demands[proper_papers]
+            self.constraint_matrix = self.constraint_matrix[:, proper_papers]
+            self.affinity_matrix = self.affinity_matrix[:, proper_papers]
+            self.best_revs = self.best_revs[:, proper_papers]
+            self.num_papers = self.num_papers - proper_papers.size
+
         ordering = self._select_ordering()
+        self.logger.debug('Ordering is {}'.format(ordering))
+
         self.solution = self.safe_rr(ordering)
+
+        if self.solution is None:
+            self.logger.debug('GRRR was unable to find a WEF1 allocation satisfying all papers\' demands. '
+                              'Falling back to picking sequence without WEF1 guarantees.')
+            self.solution = self.rr(ordering)
+
+            if self.solution is None:
+                raise SolverException(
+                    'Solver could not find a solution. Adjust your parameters.')
+
+        if improper_papers:
+            self.demands = saved_demands
+            self.constraint_matrix = saved_constraint_matrix
+            self.affinity_matrix = saved_affinity_matrix
+
+            n = self.affinity_matrix.shape[0]
+            idx = 0
+            soln = np.zeros(self.affinity_matrix.shape, dtype=bool)
+            for i in range(n):
+                if i in proper_papers:
+                    soln[:, i] = self.solution[:, idx]
+                    idx += 1
+            self.solution = soln
+
+        self.logger.debug('USW: {}'.format(np.sum(self.affinity_matrix * self.solution)))
 
         self.solved = True
         return self.sol_as_mat().transpose()

--- a/tests/test_solvers_fairflow.py
+++ b/tests/test_solvers_fairflow.py
@@ -185,7 +185,7 @@ def test_solver_fairflow_no_0_score_assignment():
     Tests 5 papers, 4 reviewers.
     Reviewers review min: 1, max: 3 papers.
     Each paper needs 2 reviews.
-    No constraints.
+    Reviewer 0 cannot review paper 1.
     Purpose: Assert that an assignment is never made for 0 or less score
     """
     aggregate_score_matrix = np.transpose(
@@ -405,10 +405,10 @@ def test_solver_fairflow_respect_minimums():
 
     # make sure every reviewer is reviewing 2 papers
     nrows, ncols = res.shape if len(res.shape) == 2 else (0, 0)
-    for rix in range(nrows):
+    for rix in range(ncols):
         reviewer_count_reviews = 0
-        for pix in range(ncols):
-            if res[rix, pix] != 0:
+        for pix in range(nrows):
+            if res[pix, rix] != 0:
                 reviewer_count_reviews += 1
         assert reviewer_count_reviews == 2
 
@@ -449,10 +449,10 @@ def test_solver_fairflow_respect_minimums_2():
     assert solver.solved
     # make sure every reviewer has at least 1 paper
     nrows, ncols = res.shape if len(res.shape) == 2 else (0, 0)
-    for rix in range(nrows):
+    for rix in range(ncols):
         reviewer_count_reviews = 0
-        for pix in range(ncols):
-            if res[rix, pix] != 0:
+        for pix in range(nrows):
+            if res[pix, rix] != 0:
                 reviewer_count_reviews += 1
         assert reviewer_count_reviews >= 1
 
@@ -493,12 +493,12 @@ def test_solver_fairflow_respect_minimums_3():
     assert solver.solved
     # make sure every reviewer has at least 1 paper
     nrows, ncols = res.shape if len(res.shape) == 2 else (0, 0)
-    for rix in range(nrows):
+    for rix in range(ncols):
         reviewer_count_reviews = 0
-        for pix in range(ncols):
-            if res[rix, pix] != 0:
+        for pix in range(nrows):
+            if res[pix, rix] != 0:
                 reviewer_count_reviews += 1
-        assert reviewer_count_reviews >= 1
+        assert reviewer_count_reviews >= 2
 
 
 def test_solver_fairflow_respects_one_minimum():
@@ -538,10 +538,10 @@ def test_solver_fairflow_respects_one_minimum():
     assert solver.solved
     # make sure every reviewer has at least 1 paper
     nrows, ncols = res.shape if len(res.shape) == 2 else (0, 0)
-    for rix in range(nrows):
+    for rix in range(ncols):
         reviewer_count_reviews = 0
-        for pix in range(ncols):
-            if res[rix, pix] != 0:
+        for pix in range(nrows):
+            if res[pix, rix] != 0:
                 reviewer_count_reviews += 1
         assert reviewer_count_reviews >= 1
 
@@ -582,12 +582,12 @@ def test_solver_fairflow_respects_two_minimum():
     assert solver.solved
     # make sure every reviewer has at least 1 paper
     nrows, ncols = res.shape if len(res.shape) == 2 else (0, 0)
-    for rix in range(nrows):
+    for rix in range(ncols):
         reviewer_count_reviews = 0
-        for pix in range(ncols):
-            if res[rix, pix] != 0:
+        for pix in range(nrows):
+            if res[pix, rix] != 0:
                 reviewer_count_reviews += 1
-        assert reviewer_count_reviews >= 1
+        assert reviewer_count_reviews >= 2
 
 
 def test_solver_fairflow_avoid_zero_scores_get_no_solution():

--- a/tests/test_solvers_grrr.py
+++ b/tests/test_solvers_grrr.py
@@ -1,0 +1,338 @@
+from collections import namedtuple
+import pytest
+import numpy as np
+from matcher.solvers import SolverException, GRRR
+from conftest import assert_arrays
+
+encoder = namedtuple('Encoder', ['aggregate_score_matrix', 'constraint_matrix'])
+
+def test_solvers_grrr_random():
+    '''When costs are all zero, compute random assignments'''
+    aggregate_score_matrix_A = np.transpose(np.array([
+        [0, 0, 0],
+        [0, 0, 0],
+        [0, 0, 0],
+        [0, 0, 0]
+    ]))
+    constraint_matrix = np.zeros(np.shape(aggregate_score_matrix_A))
+    demands = [2,2,2]
+    solver_A = GRRR(
+        [0,0,0,0],
+        [2,2,2,2],
+        demands,
+        encoder(aggregate_score_matrix_A, constraint_matrix)
+    )
+    res_A = solver_A.solve()
+    assert res_A.shape == (3,4)
+    assert solver_A.solved
+
+    aggregate_score_matrix_B = np.transpose(np.array([
+        [0, 0, 0],
+        [0, 0, 0],
+        [0, 0, 0],
+        [0, 0, 0]
+    ]))
+    constraint_matrix = np.zeros(np.shape(aggregate_score_matrix_B))
+    solver_B = GRRR(
+        [0,0,0,0],
+        [2,2,2,2],
+        demands,
+        encoder(aggregate_score_matrix_B, constraint_matrix)
+    )
+    res_B = solver_B.solve()
+    assert res_B.shape == (3,4)
+    assert solver_B.solved
+
+    # ensure that the affinity matrices are random
+    # (i.e. overwhelmingly likely to be different)
+    assert not np.array_equal(solver_A.affinity_matrix, solver_B.affinity_matrix)
+    result_A = [assignments for assignments in np.sum(res_A, axis=1)]
+    assert_arrays(result_A, demands)
+    result_B = [assignments for assignments in np.sum(res_B, axis=1)]
+    assert_arrays(result_B, demands)
+
+def test_solvers_grrr_custom_supply():
+    '''
+    Tests 3 papers, 4 reviewers.
+    Reviewers review min: 0, max: [2,1,2,1] papers respectively.
+    Each papers needs 2 reviews.
+    No constraints.
+    Purpose: Assert that reviewers are assigned papers correctly based on their supply.
+    '''
+    aggregate_score_matrix_A = np.transpose(np.array([
+        [0.2, 0.1, 0.4],
+        [0.5, 0.2, 0.3],
+        [0.2, 0.0, 0.6],
+        [0.7, 0.9, 0.3]
+    ]))
+    constraint_matrix = np.zeros(np.shape(aggregate_score_matrix_A))
+    demands = [2,2,2]
+    solver_A = GRRR(
+        [0,0,0,0],
+        [2,1,2,1],
+        demands,
+        encoder(aggregate_score_matrix_A, constraint_matrix)
+    )
+    res_A = solver_A.solve()
+    assert res_A.shape == (3,4)
+    result_demands = [assignments for assignments in np.sum(res_A, axis=1)]
+    assert_arrays(result_demands, demands)
+    result_supply = [assignments for assignments in np.sum(res_A, axis=0)]
+    assert_arrays(result_supply, [2,1,2,1])
+
+def test_solver_grrr_fail_with_supply_mins():
+    '''
+    Test to ensure that the GRRR solver's 'solved' attribute is correctly set
+    when we pass in reviewer minimums. This setting is not supported by GRRR.
+    '''
+    num_papers = 3
+    num_reviewers = 4
+    aggregate_score_matrix = np.zeros((num_papers, num_reviewers))
+    constraint_matrix = np.zeros(np.shape(aggregate_score_matrix))
+
+    minimums = [1] * num_reviewers
+    maximums = [2] * num_reviewers
+    demands = [2] * num_papers
+
+    solver = GRRR(
+        minimums,
+        maximums,
+        demands,
+        encoder(aggregate_score_matrix, constraint_matrix)
+    )
+
+    with pytest.raises(SolverException,
+                       match=r'GRRR does not currently support minimum values for number of papers per reviewer'):
+        solver.solve()
+
+    assert not solver.solved
+
+def test_solver_grrr_fail_with_custom_demands():
+    '''
+    Test to ensure that the GRRR solver's 'solved' attribute is correctly set
+    when we pass in non-uniform paper demands. This setting is not supported by GRRR.
+    '''
+
+    num_papers = 3
+    num_reviewers = 4
+    aggregate_score_matrix = np.zeros((num_papers, num_reviewers))
+    constraint_matrix = np.zeros(np.shape(aggregate_score_matrix))
+
+    minimums = [0] * num_reviewers
+    maximums = [2] * num_reviewers
+    demands = [2,1,2]
+
+    solver = GRRR(
+        minimums,
+        maximums,
+        demands,
+        encoder(aggregate_score_matrix, constraint_matrix)
+    )
+
+    with pytest.raises(SolverException,
+                       match=r'GRRR does not currently support different demands for each paper'):
+        solver.solve()
+
+    assert not solver.solved
+
+def test_solver_grrr_impossible_constraints():
+    '''
+    Test to ensure that the GRRR solver's 'solved' attribute is correctly set
+    when no solution is possible due to constraints.
+    '''
+
+    # 20 papers, 5 reviewers
+    num_papers = 20
+    num_reviewers = 5
+    aggregate_score_matrix = np.zeros((num_papers, num_reviewers))
+    constraint_matrix = -1 * np.ones((num_papers, num_reviewers)) # all pairs are constrained! should be impossible
+
+    minimums = [0] * 5
+    maximums = [20] * 5
+    demands = [3] * 20
+
+    solver = GRRR(
+        minimums,
+        maximums,
+        demands,
+        encoder(aggregate_score_matrix, constraint_matrix)
+    )
+
+    with pytest.raises(SolverException):
+        solver.solve()
+
+    assert not solver.solved
+
+def test_solver_grrr_respects_constraints():
+    '''
+    Tests 5 papers, 4 reviewers.
+    Reviewers review min: 0, max: 4 papers.
+    Each paper needs 2 reviews.
+    Constrained such that:
+    Reviewer 0: available for all papers
+             1: cannot review papers 2,3
+             2: cannot review papers 2,3
+             3: cannot review papers 0,1
+    All scores set to 1 so that any match that does not violate constraints is optimal.
+    Purpose:  Honors constraints in its solution
+    '''
+    aggregate_score_matrix = np.transpose(np.array([
+        [1, 1, 1, 1, 1],
+        [1, 1, 1, 1, 1],
+        [1, 1, 1, 1, 1],
+        [1, 1, 1, 1, 1]]))
+    constraint_matrix = np.transpose(np.array([
+        [0, 0, 0, 0, 0],
+        [0, 0, -1, -1, 0],
+        [0, 0, -1, -1, 0],
+        [-1, -1, 0, 0, 0]]))
+
+    solver = GRRR(
+        [0,0,0,0],
+        [4,4,4,4],
+        [2,2,2,2,2],
+        encoder(aggregate_score_matrix, constraint_matrix)
+    )
+
+    res = solver.solve()
+    assert res.shape == (5, 4)
+    assert solver.solved
+    # make sure result does not violate constraints
+    nrows, ncols = res.shape if len(res.shape) == 2 else (0,0)
+    for i in range(nrows):
+        for j in range(ncols):
+            assert not (constraint_matrix[i,j] == -1 and res[i,j] > 0), "Solution violates constraint at [{},{}]".format(i,j)
+
+def test_solver_grrr_respect_constraints_2():
+    '''
+    Tests 5 papers, 4 reviewers.
+    Reviewers review min: 0, max: 3 papers.
+    Each paper needs 2 reviews.
+    Constrained such that:
+    Reviewer 0: available for all papers
+             1: cannot review papers 0,3
+             2: cannot review papers 3,4
+             3: cannot review papers 1,2
+    Purpose: Honors constraints in its solution
+    '''
+    aggregate_score_matrix = np.transpose(np.array([
+        [-10, 1, 1, -10, -10],
+        [-100, -10, -10, -100, 1],
+        [1, -10, -10, -100, -100],
+        [-10, -100, -100, -10, -10]]))
+    constraint_matrix = np.transpose(np.array([
+        [0, 0, 0, 0, 0],
+        [-1, 0, 0, -1, 0],
+        [0, 0 , 0, -1, -1],
+        [0, -1,-1, 0, 0]]))
+
+    solver = GRRR(
+        [0,0,0,0],
+        [3,3,3,3],
+        [2,2,2,2,2],
+        encoder(aggregate_score_matrix, constraint_matrix)
+    )
+    res = solver.solve()
+    assert res.shape == (5, 4)
+    assert solver.solved
+    # make sure result does not violate constraints
+    nrows, ncols = res.shape if len(res.shape) == 2 else (0,0)
+    for i in range(nrows):
+        for j in range(ncols):
+            assert not (constraint_matrix[i,j] == -1 and res[i,j] > 0), "Solution violates constraint at [{},{}]".format(i,j)
+
+def ef1(allocation, affinities):
+    '''
+    Checks if the allocation is envy-free up to 1 item (EF1).
+    Not a test, but is a criterion for the remaining tests.
+
+    Args:
+        allocation - (2d numpy array) assignment of reviewers to papers
+        affinities - (2d numpy array) affinities between papers and reviewers
+
+    Returns:
+        True if the allocation satisfies the EF1 criterion, otherwise False.
+    '''
+    n = allocation.shape[0]
+    for i in range(n):
+        # i's value for self
+        i_value_i = np.sum(allocation[i, :] * affinities[i, :])
+        for j in range(n):
+            # i's lowest value for j, minus a good
+            i_value_j_up_to_1 = np.sum(allocation[j, :] * affinities[i, :]) - np.max(allocation[j, :] * affinities[i, :])
+            if i_value_j_up_to_1 > i_value_i:
+                return False
+    return True
+
+def test_solver_grrr_envy_free_up_to_one_item():
+    '''
+    Tests 10 papers, 15 reviewers, for 10 random affinity matrices.
+    Reviewers review min: 0, max: 3 papers.
+    Each paper needs 3 reviews.
+    No constraints.
+    Purpose: Ensure that the GRRR solver returns allocations that are envy-free up to 1 item.
+    '''
+    num_papers = 10
+    num_reviewers = 15
+
+    aggregate_score_matrix = np.zeros((num_papers, num_reviewers))
+    constraint_matrix = np.zeros(np.shape(aggregate_score_matrix))
+
+    minimums = [0] * num_reviewers
+    maximums = [3] * num_reviewers
+    demands = [3] * num_papers
+
+    for _ in range(10):
+        solver = GRRR(
+            minimums,
+            maximums,
+            demands,
+            encoder(aggregate_score_matrix, constraint_matrix)
+        )
+        res = solver.solve()
+
+        assert res.shape == (10, 15)
+        assert solver.solved
+        assert ef1(res, solver.affinity_matrix.transpose())
+
+def test_solver_grrr_envy_free_up_to_one_item_constrained():
+    '''
+    Tests 10 papers, 15 reviewers, for 10 random affinity matrices.
+    Reviewers review min: 0, max: 3 papers.
+    Each paper needs 3 reviews.
+    Constraints chosen at random, with a 10% chance of any given constraint.
+    Purpose: Ensure that the GRRR solver returns allocations that are envy-free up to 1 item and satisfy constraints.
+    '''
+    num_papers = 10
+    num_reviewers = 15
+
+    aggregate_score_matrix = np.zeros((num_papers, num_reviewers))
+    shape = np.shape(aggregate_score_matrix)
+
+    minimums = [0] * num_reviewers
+    maximums = [3] * num_reviewers
+    demands = [3] * num_papers
+
+    for _ in range(10):
+        constraint_matrix = np.where(
+            np.random.rand(shape[0], shape[1]) > 0.1,
+            np.zeros(shape),
+            -1 * np.ones(shape))
+
+        solver = GRRR(
+            minimums,
+            maximums,
+            demands,
+            encoder(aggregate_score_matrix, constraint_matrix)
+        )
+        res = solver.solve()
+
+        assert res.shape == (10, 15)
+        assert solver.solved
+        assert ef1(res, solver.affinity_matrix.transpose())
+
+        nrows, ncols = res.shape if len(res.shape) == 2 else (0, 0)
+        for i in range(nrows):
+            for j in range(ncols):
+                assert not (constraint_matrix[i, j] == -1 and res[
+                    i, j] > 0), "Solution violates constraint at [{},{}]".format(i, j)


### PR DESCRIPTION
This branch implements the Greedy Reviewer Round Robin algorithm of https://arxiv.org/pdf/2108.02126.pdf, modified to use the picking sequence from https://ifaamas.org/Proceedings/aamas2020/pdfs/p231.pdf. 

The returned reviewer assignment is weighted envy free up to 1 item (WEF1). An envy-free (EF) allocation would ensure no paper prefers the reviewers assigned to another paper - weighted EF1 is a relaxation of envy-freeness that applies when papers have uneven reviewer demands. The assignment algorithm can also support min/max reviewer supply constraints.