### PR TITLE
Remove profile validation

### DIFF
--- a/matcher/service/openreview_interface.py
+++ b/matcher/service/openreview_interface.py
@@ -37,13 +37,6 @@ class BaseConfigNoteInterface:
             group = openreview.tools.replace_members_with_ids(
                 self.client, group
             )
-            for member in group.members:
-                if not member.startswith("~"):
-                    raise openreview.OpenReviewException(
-                        "All members of the group, {group}, must have an OpenReview Profile".format(
-                            group=group_id
-                        )
-                    )
         except openreview.OpenReviewException as error_handle:
             self.set_status(MatcherStatus.ERROR, message=str(error_handle))
             raise error_handle

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         "pre-commit",
         "celery",
         "redis",
+        "importlib-metadata<5.0"
     ],
     extras_require={
         "full": ["flower"],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -130,16 +130,16 @@ def clean_start_conference_v2(
 
     now = datetime.datetime.utcnow()
 
-    venue.set_submission_stage(
-        openreview.builder.SubmissionStage(
-            readers=[
-                openreview.builder.SubmissionStage.Readers.REVIEWERS_ASSIGNED
-            ],
-            due_date=now + datetime.timedelta(minutes=10),
-            withdrawn_submission_reveal_authors=True,
-            desk_rejected_submission_reveal_authors=True,
-        )
+    venue.submission_stage = openreview.stages.SubmissionStage(
+        double_blind=True,
+        readers=[
+            openreview.builder.SubmissionStage.Readers.REVIEWERS_ASSIGNED
+        ],
+        due_date=now + datetime.timedelta(minutes=10),
+        withdrawn_submission_reveal_authors=True,
+        desk_rejected_submission_reveal_authors=True,
     )
+    venue.create_submission_stage()
 
     reviewers = set()
 

--- a/tests/test_integration_api2_fairflow.py
+++ b/tests/test_integration_api2_fairflow.py
@@ -980,7 +980,7 @@ def test_integration_group_not_found_error(
     )
 
 
-def test_integration_group_validity_error(
+def test_integration_group_with_email(
     openreview_context, celery_app, celery_worker
 ):
     """
@@ -993,7 +993,7 @@ def test_integration_group_validity_error(
     num_reviewers = 10
     num_papers = 10
     reviews_per_paper = 3
-    max_papers = 5
+    max_papers = 7
     min_papers = 1
     alternates = 0
 
@@ -1011,7 +1011,7 @@ def test_integration_group_validity_error(
     reviewers_id = venue.get_reviewers_id()
 
     config = {
-        "title": {"value": "integration-test"},
+        "title": {"value": "integration-test-validity"},
         "user_demand": {"value": str(reviews_per_paper)},
         "max_papers": {"value": str(max_papers)},
         "min_papers": {"value": str(min_papers)},
@@ -1049,6 +1049,7 @@ def test_integration_group_validity_error(
         },
         "status": {"value": "Initialized"},
         "solver": {"value": "FairFlow"},
+        "allow_zero_score_assignments": {"value": "Yes"}
     }
 
     config_note = openreview_client.post_note_edit(
@@ -1064,13 +1065,9 @@ def test_integration_group_validity_error(
         content_type="application/json",
         headers=openreview_client.headers,
     )
-    assert response.status_code == 500
+    assert response.status_code == 200
 
     matcher_status = wait_for_status(
-        openreview_client, config_note["note"]["id"]
+        openreview_client, config_note["note"]["id"], api_version=2
     )
-    assert matcher_status.content["status"]["value"] == "Error"
-    assert (
-        matcher_status.content["error_message"]["value"]
-        == "All members of the group, AKBD.ws/2029/Conference/Reviewers, must have an OpenReview Profile"
-    )
+    assert matcher_status.content["status"]["value"] == "Complete"

--- a/tests/test_integration_api2_fairsequence.py
+++ b/tests/test_integration_api2_fairsequence.py
@@ -984,7 +984,7 @@ def test_integration_group_not_found_error(
     )
 
 
-def test_integration_group_validity_error(
+def test_integration_group_with_email(
     openreview_context, celery_app, celery_worker
 ):
     """
@@ -994,8 +994,8 @@ def test_integration_group_validity_error(
     test_client = openreview_context["test_client"]
 
     conference_id = "NIPS.cc/2029/Conference"
-    num_reviewers = 10
-    num_papers = 10
+    num_reviewers = 1
+    num_papers = 3
     reviews_per_paper = 3
     max_papers = 5
     min_papers = 1
@@ -1053,6 +1053,7 @@ def test_integration_group_validity_error(
         },
         "status": {"value": "Initialized"},
         "solver": {"value": "FairSequence"},
+        "allow_zero_score_assignments": {"value": "Yes"}
     }
 
     config_note = openreview_client.post_note_edit(
@@ -1068,13 +1069,9 @@ def test_integration_group_validity_error(
         content_type="application/json",
         headers=openreview_client.headers,
     )
-    assert response.status_code == 500
+    assert response.status_code == 200
 
     matcher_status = wait_for_status(
-        openreview_client, config_note["note"]["id"]
+        openreview_client, config_note["note"]["id"], api_version=2
     )
-    assert matcher_status.content["status"]["value"] == "Error"
-    assert (
-        matcher_status.content["error_message"]["value"]
-        == "All members of the group, NIPS.cc/2029/Conference/Reviewers, must have an OpenReview Profile"
-    )
+    assert matcher_status.content["status"]["value"] != "Error"

--- a/tests/test_integration_fairflow.py
+++ b/tests/test_integration_fairflow.py
@@ -1184,7 +1184,7 @@ def test_integration_group_not_found_error(
     )
 
 
-def test_integration_group_validity_error(
+def test_integration_group_with_email(
     openreview_context, celery_app, celery_worker
 ):
     """
@@ -1197,7 +1197,7 @@ def test_integration_group_validity_error(
     num_reviewers = 10
     num_papers = 10
     reviews_per_paper = 3
-    max_papers = 5
+    max_papers = 7
     min_papers = 1
     alternates = 0
 
@@ -1249,6 +1249,7 @@ def test_integration_group_validity_error(
         },
         "status": "Initialized",
         "solver": "FairFlow",
+        "allow_zero_score_assignments": "Yes"
     }
 
     config_note = openreview.Note(
@@ -1270,11 +1271,7 @@ def test_integration_group_validity_error(
         content_type="application/json",
         headers=openreview_client.headers,
     )
-    assert response.status_code == 500
+    assert response.status_code == 200
 
     matcher_status = wait_for_status(openreview_client, config_note.id)
-    assert matcher_status.content["status"] == "Error"
-    assert (
-        matcher_status.content["error_message"]
-        == "All members of the group, AKBC.ws/2029/Conference/Reviewers, must have an OpenReview Profile"
-    )
+    assert matcher_status.content["status"] == "Complete"


### PR DESCRIPTION
- Resolves #246 

This PR removes the validation step for all members of a group to have an OpenReview profile, which allows for the creation of edges with email addresses. This also changes the tests to no longer expect an error when there is an email address in the match group.

There is also currently an import issue in Celery that's preventing the tests from passing on CircleCI, the solution for now is to pin `importlib-metadata<5.0` until this is fixed in the Celery code