### PR TITLE
Get papers by content: allow values with .

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
           cd ~/openreview-matcher-repo
           mkdir reports
           mkdir reports/pytest
-          python -m pytest -x -s tests --junitxml=reports/pytest/pytest-report.xml
+          python -m pytest -x tests --junitxml=reports/pytest/pytest-report.xml
     - store_test_results:
         path: reports
     - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
           cd ~/openreview-matcher-repo
           mkdir reports
           mkdir reports/pytest
-          python -m pytest -s tests --junitxml=reports/pytest/pytest-report.xml
+          python -m pytest -x -s tests --junitxml=reports/pytest/pytest-report.xml
     - store_test_results:
         path: reports
     - store_artifacts:

--- a/matcher/service/openreview_interface.py
+++ b/matcher/service/openreview_interface.py
@@ -815,7 +815,7 @@ class Deployment:
         try:
             venue = None
             self.config_note_interface.set_status(MatcherStatus.DEPLOYING)
-            support_user = 'openreview.net/Support'
+            support_user = 'OpenReview.net/Support'
             urls = openreview.tools.get_base_urls(self.config_note_interface.client)
             client_v1 = openreview.Client(baseurl = urls[0], token=self.config_note_interface.client.token)
 

--- a/matcher/service/openreview_interface.py
+++ b/matcher/service/openreview_interface.py
@@ -815,23 +815,28 @@ class Deployment:
         try:
             venue = None
             self.config_note_interface.set_status(MatcherStatus.DEPLOYING)
+            support_user = 'openreview.net/Support'
+            urls = openreview.tools.get_base_urls(self.config_note_interface.client)
+            client_v1 = openreview.Client(baseurl = urls[0], token=self.config_note_interface.client.token)
 
-            notes = self.config_note_interface.client.get_notes(
-                invitation="OpenReview.net/Support/-/Request_Form",
+            notes = client_v1.get_notes(
+                invitation=f"{support_user}/-/Request_Form",
                 content={"venue_id": self.config_note_interface.venue_id},
             )
+            self.logger.debug('request form notes found', len(notes))
             if notes:
                 venue = openreview.helpers.get_conference(
-                    self.config_note_interface.client, notes[0].id
+                    client_v1, notes[0].id, support_user = support_user
                 )
             else:
-                notes = self.config_note_interface.client.get_notes(
-                    invitation="OpenReview.net/Support/-/Journal_Request",
+                client_v2 = openreview.api.OpenReviewClient(baseurl = urls[1], token=self.config_note_interface.client.token)
+                notes = client_v2.get_notes(
+                    invitation=f"{support_user}/-/Journal_Request",
                     content={"venue_id": self.config_note_interface.venue_id},
                 )
                 if notes:
                     venue = openreview.journal.JournalRequest.get_journal(
-                        self.config_note_interface.client, notes[0].id
+                        client_v2, notes[0].id
                     )
                 else:
                     raise openreview.OpenReviewException(

--- a/matcher/service/openreview_interface.py
+++ b/matcher/service/openreview_interface.py
@@ -688,7 +688,7 @@ class ConfigNoteInterfaceV2(BaseConfigNoteInterface):
                 for element in elements[1:]:
                     if element:
                         if element.startswith("content.") and "=" in element:
-                            key, value = element.split(".")[1].split("=")
+                            key, value = element.replace('content.', '').split("=")
                             content_dict[key] = value
                         else:
                             self.logger.debug(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,6 +84,17 @@ def initialize_superuser():
         username="openreview.net",
         password="1234",
     )
+    client_v2.post_invitation_edit(invitations=None,
+        readers=['openreview.net'],
+        writers=['openreview.net'],
+        signatures=['~Super_User1'],
+        invitation=openreview.api.Invitation(id='openreview.net/-/Edit',
+            invitees=['openreview.net'],
+            readers=['openreview.net'],
+            signatures=['~Super_User1'],
+            edit=True
+        )
+    )    
     return client, client_v2
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,6 +67,15 @@ def wait_for_status(client, config_note_id, api_version=1):
 
     raise TimeoutError("matcher did not finish")
 
+def await_queue_edit(super_client, edit_id=None, invitation=None):
+    while True:
+        process_logs = super_client.get_process_logs(id=edit_id, invitation=invitation)
+        if process_logs:
+            break
+
+        time.sleep(0.5)
+
+    assert process_logs[0]['status'] == 'ok'
 
 def initialize_superuser():
     """register and activate the superuser account"""
@@ -137,8 +146,7 @@ def clean_start_conference_v2(
 
     venue = Venue(openreview_client, conference_id, support_user='openreview.net/Support')
     venue.use_area_chairs = True
-    venue.setup()
-
+    
     now = datetime.datetime.utcnow()
 
     venue.submission_stage = openreview.stages.SubmissionStage(
@@ -150,23 +158,25 @@ def clean_start_conference_v2(
         withdrawn_submission_reveal_authors=True,
         desk_rejected_submission_reveal_authors=True,
     )
+    venue.setup()
     venue.create_submission_stage()
 
     reviewers = set()
 
     scores_string = ""
     with open(AFFINITY_SCORE_FILE, "w") as file_handle:
+        authors = []
+        authorids = []
+        for letter in ["a", "b", "c"]:
+            authors.append(f'Matching Author{letter.upper()}')
+            authorids.append(f'~Matching_Author{letter.upper()}1')
+        
+        user_client = openreview.api.OpenReviewClient(username='author@maila.com', password='1234')
+
         for paper_number in range(num_papers):
-
-            authorids = [
-                "~Test_Author{1}{0}".format(paper_number, author_code)
-                for author_code in ["a", "b", "c"]
-            ]
-            authors = ["Author Author" for _ in ["A", "B", "C"]]
-
-            posted_submission = openreview_client.post_note_edit(
+            posted_submission = user_client.post_note_edit(
                 invitation=f"{conference_id}/-/Submission",
-                signatures=["~Super_User1"],
+                signatures=["~Matching_AuthorA1"],
                 note=Note(
                     content={
                         "title": {
@@ -180,6 +190,7 @@ def clean_start_conference_v2(
                     }
                 ),
             )
+            await_queue_edit(openreview_client, posted_submission['id'])
 
             for index in range(0, num_reviewers):
                 reviewer = "~User{0}_Reviewer1".format(chr(97 + index))
@@ -334,6 +345,10 @@ def openreview_context():
             "User{0}".format(chr(97 + index)),
             "Reviewer",
         )
+
+    for letter in ["a", "b", "c"]:
+        create_user(f'author@mail{letter}.com', 'Matching', f'Author{letter.upper()}')
+
     with app.app_context():
         yield {
             "app": app,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -124,7 +124,7 @@ def clean_start_conference_v2(
     reviews_per_paper,
 ):
 
-    venue = Venue(openreview_client, conference_id)
+    venue = Venue(openreview_client, conference_id, support_user='openreview.net/Support')
     venue.use_area_chairs = True
     venue.setup()
 

--- a/tests/test_integration_api2_fairflow.py
+++ b/tests/test_integration_api2_fairflow.py
@@ -48,13 +48,13 @@ def test_integration_basic(openreview_context, celery_app, celery_worker):
         },
         "paper_invitation": {"value": venue.get_submission_id()},
         "assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id)
+            "value": venue.get_assignment_id(reviewers_id)
         },
         "deployed_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, deployed=True)
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
         },
         "invite_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, invite=True)
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
         },
         "aggregate_score_invitation": {
             "value": "{}/-/Aggregate_Score".format(reviewers_id)
@@ -100,7 +100,7 @@ def test_integration_basic(openreview_context, celery_app, celery_worker):
 
     paper_assignment_edges = openreview_client.get_edges(
         label="integration-test",
-        invitation=venue.get_paper_assignment_id(venue.get_reviewers_id()),
+        invitation=venue.get_assignment_id(venue.get_reviewers_id()),
     )
 
     assert len(paper_assignment_edges) == num_papers * reviews_per_paper
@@ -144,13 +144,13 @@ def test_integration_supply_mismatch_error(
         },
         "paper_invitation": {"value": venue.get_submission_id()},
         "assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id)
+            "value": venue.get_assignment_id(reviewers_id)
         },
         "deployed_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, deployed=True)
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
         },
         "invite_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, invite=True)
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
         },
         "aggregate_score_invitation": {
             "value": "{}/-/Aggregate_Score".format(reviewers_id)
@@ -200,7 +200,7 @@ def test_integration_supply_mismatch_error(
 
     paper_assignment_edges = openreview_client.get_edges(
         label="integration-test-2",
-        invitation=venue.get_paper_assignment_id(venue.get_reviewers_id()),
+        invitation=venue.get_assignment_id(venue.get_reviewers_id()),
     )
 
     assert len(paper_assignment_edges) == 0
@@ -244,13 +244,13 @@ def test_integration_demand_out_of_supply_range_error(
         },
         "paper_invitation": {"value": venue.get_submission_id()},
         "assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id)
+            "value": venue.get_assignment_id(reviewers_id)
         },
         "deployed_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, deployed=True)
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
         },
         "invite_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, invite=True)
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
         },
         "aggregate_score_invitation": {
             "value": "{}/-/Aggregate_Score".format(reviewers_id)
@@ -300,7 +300,7 @@ def test_integration_demand_out_of_supply_range_error(
 
     paper_assignment_edges = openreview_client.get_edges(
         label="integration-test",
-        invitation=venue.get_paper_assignment_id(venue.get_reviewers_id()),
+        invitation=venue.get_assignment_id(venue.get_reviewers_id()),
     )
 
     assert len(paper_assignment_edges) == 0
@@ -342,13 +342,13 @@ def test_integration_no_scores(openreview_context, celery_app, celery_worker):
         },
         "paper_invitation": {"value": venue.get_submission_id()},
         "assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id)
+            "value": venue.get_assignment_id(reviewers_id)
         },
         "deployed_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, deployed=True)
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
         },
         "invite_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, invite=True)
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
         },
         "aggregate_score_invitation": {
             "value": "{}/-/Aggregate_Score".format(reviewers_id)
@@ -389,7 +389,7 @@ def test_integration_no_scores(openreview_context, celery_app, celery_worker):
 
     paper_assignment_edges = openreview_client.get_edges(
         label="integration-test",
-        invitation=venue.get_paper_assignment_id(venue.get_reviewers_id()),
+        invitation=venue.get_assignment_id(venue.get_reviewers_id()),
     )
 
     assert len(paper_assignment_edges) == num_papers * reviews_per_paper
@@ -431,13 +431,13 @@ def test_routes_invalid_invitation(
         },
         "paper_invitation": {"value": venue.get_submission_id()},
         "assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id)
+            "value": venue.get_assignment_id(reviewers_id)
         },
         "deployed_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, deployed=True)
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
         },
         "invite_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, invite=True)
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
         },
         "aggregate_score_invitation": {
             "value": "{}/-/Aggregate_Score".format(reviewers_id)
@@ -515,13 +515,13 @@ def test_routes_missing_header(openreview_context, celery_app, celery_worker):
         },
         "paper_invitation": {"value": venue.get_submission_id()},
         "assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id)
+            "value": venue.get_assignment_id(reviewers_id)
         },
         "deployed_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, deployed=True)
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
         },
         "invite_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, invite=True)
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
         },
         "aggregate_score_invitation": {
             "value": "{}/-/Aggregate_Score".format(reviewers_id)
@@ -628,13 +628,13 @@ def test_routes_already_running_or_complete(
         },
         "paper_invitation": {"value": venue.get_submission_id()},
         "assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id)
+            "value": venue.get_assignment_id(reviewers_id)
         },
         "deployed_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, deployed=True)
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
         },
         "invite_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, invite=True)
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
         },
         "aggregate_score_invitation": {
             "value": "{}/-/Aggregate_Score".format(reviewers_id)
@@ -734,13 +734,13 @@ def test_routes_already_queued(openreview_context, celery_app, celery_worker):
         },
         "paper_invitation": {"value": venue.get_submission_id()},
         "assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id)
+            "value": venue.get_assignment_id(reviewers_id)
         },
         "deployed_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, deployed=True)
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
         },
         "invite_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, invite=True)
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
         },
         "aggregate_score_invitation": {
             "value": "{}/-/Aggregate_Score".format(reviewers_id)
@@ -821,13 +821,13 @@ def test_integration_empty_reviewers_list_error(
         },
         "paper_invitation": {"value": venue.get_submission_id()},
         "assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id)
+            "value": venue.get_assignment_id(reviewers_id)
         },
         "deployed_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, deployed=True)
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
         },
         "invite_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, invite=True)
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
         },
         "aggregate_score_invitation": {
             "value": "{}/-/Aggregate_Score".format(reviewers_id)
@@ -882,7 +882,7 @@ def test_integration_empty_reviewers_list_error(
 
     paper_assignment_edges = openreview_client.get_edges(
         label="integration-test",
-        invitation=venue.get_paper_assignment_id(venue.get_reviewers_id()),
+        invitation=venue.get_assignment_id(venue.get_reviewers_id()),
     )
 
     assert len(paper_assignment_edges) == 0
@@ -926,13 +926,13 @@ def test_integration_group_not_found_error(
         },
         "paper_invitation": {"value": venue.get_submission_id()},
         "assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id)
+            "value": venue.get_assignment_id(reviewers_id)
         },
         "deployed_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, deployed=True)
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
         },
         "invite_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, invite=True)
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
         },
         "aggregate_score_invitation": {
             "value": "{}/-/Aggregate_Score".format(reviewers_id)
@@ -1021,13 +1021,13 @@ def test_integration_group_with_email(
         },
         "paper_invitation": {"value": venue.get_submission_id()},
         "assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id)
+            "value": venue.get_assignment_id(reviewers_id)
         },
         "deployed_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, deployed=True)
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
         },
         "invite_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, invite=True)
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
         },
         "aggregate_score_invitation": {
             "value": "{}/-/Aggregate_Score".format(reviewers_id)

--- a/tests/test_integration_api2_fairflow.py
+++ b/tests/test_integration_api2_fairflow.py
@@ -859,9 +859,16 @@ def test_integration_empty_reviewers_list_error(
     assert config_note
 
     # Empty the list of reviewers before calling the matching
-    reviewers_group = openreview_client.get_group(reviewers_id)
-    reviewers_group.members = []
-    openreview_client.post_group(reviewers_group)
+    openreview_client.post_group_edit(
+            invitation = venue.get_meta_invitation_id(),
+            readers = [venue.venue_id],
+            writers = [venue.venue_id],
+            signatures = [venue.venue_id],
+            group = openreview.api.Group(
+                id = reviewers_id,
+                members = []
+            )
+        )
 
     response = test_client.post(
         "/match",

--- a/tests/test_integration_api2_fairsequence.py
+++ b/tests/test_integration_api2_fairsequence.py
@@ -48,13 +48,13 @@ def test_integration_basic(openreview_context, celery_app, celery_worker):
         },
         "paper_invitation": {"value": venue.get_submission_id()},
         "assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id)
+            "value": venue.get_assignment_id(reviewers_id)
         },
         "deployed_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, deployed=True)
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
         },
         "invite_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, invite=True)
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
         },
         "aggregate_score_invitation": {
             "value": "{}/-/Aggregate_Score".format(reviewers_id)
@@ -100,7 +100,7 @@ def test_integration_basic(openreview_context, celery_app, celery_worker):
 
     paper_assignment_edges = openreview_client.get_edges(
         label="integration-test",
-        invitation=venue.get_paper_assignment_id(venue.get_reviewers_id()),
+        invitation=venue.get_assignment_id(venue.get_reviewers_id()),
     )
 
     assert len(paper_assignment_edges) == num_papers * reviews_per_paper
@@ -144,13 +144,13 @@ def test_integration_supply_mismatch_error(
         },
         "paper_invitation": {"value": venue.get_submission_id()},
         "assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id)
+            "value": venue.get_assignment_id(reviewers_id)
         },
         "deployed_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, deployed=True)
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
         },
         "invite_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, invite=True)
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
         },
         "aggregate_score_invitation": {
             "value": "{}/-/Aggregate_Score".format(reviewers_id)
@@ -200,7 +200,7 @@ def test_integration_supply_mismatch_error(
 
     paper_assignment_edges = openreview_client.get_edges(
         label="integration-test-2",
-        invitation=venue.get_paper_assignment_id(venue.get_reviewers_id()),
+        invitation=venue.get_assignment_id(venue.get_reviewers_id()),
     )
 
     assert len(paper_assignment_edges) == 0
@@ -244,13 +244,13 @@ def test_integration_demand_out_of_supply_range_error(
         },
         "paper_invitation": {"value": venue.get_submission_id()},
         "assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id)
+            "value": venue.get_assignment_id(reviewers_id)
         },
         "deployed_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, deployed=True)
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
         },
         "invite_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, invite=True)
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
         },
         "aggregate_score_invitation": {
             "value": "{}/-/Aggregate_Score".format(reviewers_id)
@@ -300,7 +300,7 @@ def test_integration_demand_out_of_supply_range_error(
 
     paper_assignment_edges = openreview_client.get_edges(
         label="integration-test",
-        invitation=venue.get_paper_assignment_id(venue.get_reviewers_id()),
+        invitation=venue.get_assignment_id(venue.get_reviewers_id()),
     )
 
     assert len(paper_assignment_edges) == 0
@@ -342,13 +342,13 @@ def test_integration_no_scores(openreview_context, celery_app, celery_worker):
         },
         "paper_invitation": {"value": venue.get_submission_id()},
         "assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id)
+            "value": venue.get_assignment_id(reviewers_id)
         },
         "deployed_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, deployed=True)
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
         },
         "invite_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, invite=True)
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
         },
         "aggregate_score_invitation": {
             "value": "{}/-/Aggregate_Score".format(reviewers_id)
@@ -389,7 +389,7 @@ def test_integration_no_scores(openreview_context, celery_app, celery_worker):
 
     paper_assignment_edges = openreview_client.get_edges(
         label="integration-test",
-        invitation=venue.get_paper_assignment_id(venue.get_reviewers_id()),
+        invitation=venue.get_assignment_id(venue.get_reviewers_id()),
     )
 
     assert len(paper_assignment_edges) == num_papers * reviews_per_paper
@@ -431,13 +431,13 @@ def test_routes_invalid_invitation(
         },
         "paper_invitation": {"value": venue.get_submission_id()},
         "assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id)
+            "value": venue.get_assignment_id(reviewers_id)
         },
         "deployed_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, deployed=True)
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
         },
         "invite_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, invite=True)
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
         },
         "aggregate_score_invitation": {
             "value": "{}/-/Aggregate_Score".format(reviewers_id)
@@ -515,13 +515,13 @@ def test_routes_missing_header(openreview_context, celery_app, celery_worker):
         },
         "paper_invitation": {"value": venue.get_submission_id()},
         "assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id)
+            "value": venue.get_assignment_id(reviewers_id)
         },
         "deployed_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, deployed=True)
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
         },
         "invite_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, invite=True)
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
         },
         "aggregate_score_invitation": {
             "value": "{}/-/Aggregate_Score".format(reviewers_id)
@@ -628,13 +628,13 @@ def test_routes_already_running_or_complete(
         },
         "paper_invitation": {"value": venue.get_submission_id()},
         "assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id)
+            "value": venue.get_assignment_id(reviewers_id)
         },
         "deployed_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, deployed=True)
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
         },
         "invite_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, invite=True)
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
         },
         "aggregate_score_invitation": {
             "value": "{}/-/Aggregate_Score".format(reviewers_id)
@@ -734,13 +734,13 @@ def test_routes_already_queued(openreview_context, celery_app, celery_worker):
         },
         "paper_invitation": {"value": venue.get_submission_id()},
         "assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id)
+            "value": venue.get_assignment_id(reviewers_id)
         },
         "deployed_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, deployed=True)
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
         },
         "invite_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, invite=True)
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
         },
         "aggregate_score_invitation": {
             "value": "{}/-/Aggregate_Score".format(reviewers_id)
@@ -821,13 +821,13 @@ def test_integration_empty_reviewers_list_error(
         },
         "paper_invitation": {"value": venue.get_submission_id()},
         "assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id)
+            "value": venue.get_assignment_id(reviewers_id)
         },
         "deployed_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, deployed=True)
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
         },
         "invite_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, invite=True)
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
         },
         "aggregate_score_invitation": {
             "value": "{}/-/Aggregate_Score".format(reviewers_id)
@@ -859,9 +859,16 @@ def test_integration_empty_reviewers_list_error(
     assert config_note
 
     # Empty the list of reviewers before calling the matching
-    reviewers_group = openreview_client.get_group(reviewers_id)
-    reviewers_group.members = []
-    openreview_client.post_group(reviewers_group)
+    openreview_client.post_group_edit(
+            invitation = venue.get_meta_invitation_id(),
+            readers = [venue.venue_id],
+            writers = [venue.venue_id],
+            signatures = [venue.venue_id],
+            group = openreview.api.Group(
+                id = reviewers_id,
+                members = []
+            )
+        )
 
     response = test_client.post(
         "/match",
@@ -882,7 +889,7 @@ def test_integration_empty_reviewers_list_error(
 
     paper_assignment_edges = openreview_client.get_edges(
         label="integration-test",
-        invitation=venue.get_paper_assignment_id(venue.get_reviewers_id()),
+        invitation=venue.get_assignment_id(venue.get_reviewers_id()),
     )
 
     assert len(paper_assignment_edges) == 0
@@ -930,13 +937,13 @@ def test_integration_group_not_found_error(
         },
         "paper_invitation": {"value": venue.get_submission_id()},
         "assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id)
+            "value": venue.get_assignment_id(reviewers_id)
         },
         "deployed_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, deployed=True)
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
         },
         "invite_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, invite=True)
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
         },
         "aggregate_score_invitation": {
             "value": "{}/-/Aggregate_Score".format(reviewers_id)
@@ -1025,13 +1032,13 @@ def test_integration_group_with_email(
         },
         "paper_invitation": {"value": venue.get_submission_id()},
         "assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id)
+            "value": venue.get_assignment_id(reviewers_id)
         },
         "deployed_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, deployed=True)
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
         },
         "invite_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, invite=True)
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
         },
         "aggregate_score_invitation": {
             "value": "{}/-/Aggregate_Score".format(reviewers_id)

--- a/tests/test_integration_api2_minmax.py
+++ b/tests/test_integration_api2_minmax.py
@@ -48,13 +48,13 @@ def test_integration_basic(openreview_context, celery_app, celery_worker):
         },
         "paper_invitation": {"value": venue.get_submission_id()},
         "assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id)
+            "value": venue.get_assignment_id(reviewers_id)
         },
         "deployed_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, deployed=True)
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
         },
         "invite_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, invite=True)
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
         },
         "aggregate_score_invitation": {
             "value": "{}/-/Aggregate_Score".format(reviewers_id)
@@ -100,7 +100,7 @@ def test_integration_basic(openreview_context, celery_app, celery_worker):
 
     paper_assignment_edges = openreview_client.get_edges(
         label="integration-test",
-        invitation=venue.get_paper_assignment_id(venue.get_reviewers_id()),
+        invitation=venue.get_assignment_id(venue.get_reviewers_id()),
     )
 
     assert len(paper_assignment_edges) == num_papers * reviews_per_paper
@@ -144,13 +144,13 @@ def test_integration_no_solution_due_to_conflicts(
         },
         "paper_invitation": {"value": venue.get_submission_id()},
         "assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id)
+            "value": venue.get_assignment_id(reviewers_id)
         },
         "deployed_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, deployed=True)
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
         },
         "invite_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, invite=True)
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
         },
         "aggregate_score_invitation": {
             "value": "{}/-/Aggregate_Score".format(reviewers_id)
@@ -214,7 +214,7 @@ def test_integration_no_solution_due_to_conflicts(
 
     paper_assignment_edges = openreview_client.get_edges(
         label="integration-test",
-        invitation=venue.get_paper_assignment_id(venue.get_reviewers_id()),
+        invitation=venue.get_assignment_id(venue.get_reviewers_id()),
     )
 
     assert len(paper_assignment_edges) == 0
@@ -258,13 +258,13 @@ def test_integration_supply_mismatch_error(
         },
         "paper_invitation": {"value": venue.get_submission_id()},
         "assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id)
+            "value": venue.get_assignment_id(reviewers_id)
         },
         "deployed_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, deployed=True)
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
         },
         "invite_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, invite=True)
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
         },
         "aggregate_score_invitation": {
             "value": "{}/-/Aggregate_Score".format(reviewers_id)
@@ -314,7 +314,7 @@ def test_integration_supply_mismatch_error(
 
     paper_assignment_edges = openreview_client.get_edges(
         label="integration-test-2",
-        invitation=venue.get_paper_assignment_id(venue.get_reviewers_id()),
+        invitation=venue.get_assignment_id(venue.get_reviewers_id()),
     )
 
     assert len(paper_assignment_edges) == 0
@@ -358,13 +358,13 @@ def test_integration_demand_out_of_supply_range_error(
         },
         "paper_invitation": {"value": venue.get_submission_id()},
         "assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id)
+            "value": venue.get_assignment_id(reviewers_id)
         },
         "deployed_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, deployed=True)
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
         },
         "invite_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, invite=True)
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
         },
         "aggregate_score_invitation": {
             "value": "{}/-/Aggregate_Score".format(reviewers_id)
@@ -414,7 +414,7 @@ def test_integration_demand_out_of_supply_range_error(
 
     paper_assignment_edges = openreview_client.get_edges(
         label="integration-test",
-        invitation=venue.get_paper_assignment_id(venue.get_reviewers_id()),
+        invitation=venue.get_assignment_id(venue.get_reviewers_id()),
     )
 
     assert len(paper_assignment_edges) == 0
@@ -456,13 +456,13 @@ def test_integration_no_scores(openreview_context, celery_app, celery_worker):
         },
         "paper_invitation": {"value": venue.get_submission_id()},
         "assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id)
+            "value": venue.get_assignment_id(reviewers_id)
         },
         "deployed_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, deployed=True)
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
         },
         "invite_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, invite=True)
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
         },
         "aggregate_score_invitation": {
             "value": "{}/-/Aggregate_Score".format(reviewers_id)
@@ -503,7 +503,7 @@ def test_integration_no_scores(openreview_context, celery_app, celery_worker):
 
     paper_assignment_edges = openreview_client.get_edges(
         label="integration-test",
-        invitation=venue.get_paper_assignment_id(venue.get_reviewers_id()),
+        invitation=venue.get_assignment_id(venue.get_reviewers_id()),
     )
 
     assert len(paper_assignment_edges) == num_papers * reviews_per_paper
@@ -545,13 +545,13 @@ def test_routes_invalid_invitation(
         },
         "paper_invitation": {"value": venue.get_submission_id()},
         "assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id)
+            "value": venue.get_assignment_id(reviewers_id)
         },
         "deployed_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, deployed=True)
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
         },
         "invite_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, invite=True)
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
         },
         "aggregate_score_invitation": {
             "value": "{}/-/Aggregate_Score".format(reviewers_id)
@@ -629,13 +629,13 @@ def test_routes_missing_header(openreview_context, celery_app, celery_worker):
         },
         "paper_invitation": {"value": venue.get_submission_id()},
         "assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id)
+            "value": venue.get_assignment_id(reviewers_id)
         },
         "deployed_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, deployed=True)
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
         },
         "invite_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, invite=True)
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
         },
         "aggregate_score_invitation": {
             "value": "{}/-/Aggregate_Score".format(reviewers_id)
@@ -742,13 +742,13 @@ def test_routes_already_running_or_complete(
         },
         "paper_invitation": {"value": venue.get_submission_id()},
         "assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id)
+            "value": venue.get_assignment_id(reviewers_id)
         },
         "deployed_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, deployed=True)
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
         },
         "invite_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, invite=True)
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
         },
         "aggregate_score_invitation": {
             "value": "{}/-/Aggregate_Score".format(reviewers_id)

--- a/tests/test_integration_api2_queue.py
+++ b/tests/test_integration_api2_queue.py
@@ -47,13 +47,13 @@ def test_integration_basic(openreview_context, celery_app, celery_worker):
         },
         "paper_invitation": {"value": venue.get_submission_id()},
         "assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id)
+            "value": venue.get_assignment_id(reviewers_id)
         },
         "deployed_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, deployed=True)
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
         },
         "invite_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, invite=True)
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
         },
         "aggregate_score_invitation": {
             "value": "{}/-/Aggregate_Score".format(reviewers_id)

--- a/tests/test_integration_api2_randomized.py
+++ b/tests/test_integration_api2_randomized.py
@@ -53,13 +53,13 @@ def test_integration_basic(openreview_context, celery_app, celery_worker):
         },
         "paper_invitation": {"value": venue.get_submission_id()},
         "assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id)
+            "value": venue.get_assignment_id(reviewers_id)
         },
         "deployed_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, deployed=True)
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
         },
         "invite_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, invite=True)
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
         },
         "aggregate_score_invitation": {
             "value": "{}/-/Aggregate_Score".format(reviewers_id)
@@ -106,7 +106,7 @@ def test_integration_basic(openreview_context, celery_app, celery_worker):
 
     paper_assignment_edges = openreview_client.get_edges(
         label="integration-test",
-        invitation=venue.get_paper_assignment_id(venue.get_reviewers_id()),
+        invitation=venue.get_assignment_id(venue.get_reviewers_id()),
     )
 
     assert len(paper_assignment_edges) == num_papers * reviews_per_paper
@@ -150,13 +150,13 @@ def test_integration_supply_mismatch_error(
         },
         "paper_invitation": {"value": venue.get_submission_id()},
         "assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id)
+            "value": venue.get_assignment_id(reviewers_id)
         },
         "deployed_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, deployed=True)
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
         },
         "invite_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, invite=True)
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
         },
         "aggregate_score_invitation": {
             "value": "{}/-/Aggregate_Score".format(reviewers_id)
@@ -206,7 +206,7 @@ def test_integration_supply_mismatch_error(
 
     paper_assignment_edges = openreview_client.get_edges(
         label="integration-test-2",
-        invitation=venue.get_paper_assignment_id(venue.get_reviewers_id()),
+        invitation=venue.get_assignment_id(venue.get_reviewers_id()),
     )
 
     assert len(paper_assignment_edges) == 0
@@ -250,13 +250,13 @@ def test_integration_demand_out_of_supply_range_error(
         },
         "paper_invitation": {"value": venue.get_submission_id()},
         "assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id)
+            "value": venue.get_assignment_id(reviewers_id)
         },
         "deployed_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, deployed=True)
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
         },
         "invite_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, invite=True)
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
         },
         "aggregate_score_invitation": {
             "value": "{}/-/Aggregate_Score".format(reviewers_id)
@@ -306,7 +306,7 @@ def test_integration_demand_out_of_supply_range_error(
 
     paper_assignment_edges = openreview_client.get_edges(
         label="integration-test",
-        invitation=venue.get_paper_assignment_id(venue.get_reviewers_id()),
+        invitation=venue.get_assignment_id(venue.get_reviewers_id()),
     )
 
     assert len(paper_assignment_edges) == 0
@@ -348,13 +348,13 @@ def test_integration_no_scores(openreview_context, celery_app, celery_worker):
         },
         "paper_invitation": {"value": venue.get_submission_id()},
         "assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id)
+            "value": venue.get_assignment_id(reviewers_id)
         },
         "deployed_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, deployed=True)
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
         },
         "invite_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, invite=True)
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
         },
         "aggregate_score_invitation": {
             "value": "{}/-/Aggregate_Score".format(reviewers_id)
@@ -395,7 +395,7 @@ def test_integration_no_scores(openreview_context, celery_app, celery_worker):
 
     paper_assignment_edges = openreview_client.get_edges(
         label="integration-test",
-        invitation=venue.get_paper_assignment_id(venue.get_reviewers_id()),
+        invitation=venue.get_assignment_id(venue.get_reviewers_id()),
     )
 
     assert len(paper_assignment_edges) == num_papers * reviews_per_paper
@@ -437,13 +437,13 @@ def test_routes_invalid_invitation(
         },
         "paper_invitation": {"value": venue.get_submission_id()},
         "assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id)
+            "value": venue.get_assignment_id(reviewers_id)
         },
         "deployed_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, deployed=True)
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
         },
         "invite_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, invite=True)
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
         },
         "aggregate_score_invitation": {
             "value": "{}/-/Aggregate_Score".format(reviewers_id)
@@ -521,13 +521,13 @@ def test_routes_missing_header(openreview_context, celery_app, celery_worker):
         },
         "paper_invitation": {"value": venue.get_submission_id()},
         "assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id)
+            "value": venue.get_assignment_id(reviewers_id)
         },
         "deployed_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, deployed=True)
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
         },
         "invite_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, invite=True)
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
         },
         "aggregate_score_invitation": {
             "value": "{}/-/Aggregate_Score".format(reviewers_id)
@@ -605,7 +605,7 @@ def test_routes_already_running_or_complete(
     openreview_client = openreview_context["openreview_client_v2"]
     test_client = openreview_context["test_client"]
 
-    conference_id = "ICML.cc/2019/Conference"
+    conference_id = "ICML.cc/2029/Conference"
     num_reviewers = 1
     num_papers = 1
     reviews_per_paper = 1
@@ -634,13 +634,13 @@ def test_routes_already_running_or_complete(
         },
         "paper_invitation": {"value": venue.get_submission_id()},
         "assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id)
+            "value": venue.get_assignment_id(reviewers_id)
         },
         "deployed_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, deployed=True)
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
         },
         "invite_assignment_invitation": {
-            "value": venue.get_paper_assignment_id(reviewers_id, invite=True)
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
         },
         "aggregate_score_invitation": {
             "value": "{}/-/Aggregate_Score".format(reviewers_id)

--- a/tests/test_integration_fairsequence.py
+++ b/tests/test_integration_fairsequence.py
@@ -1100,7 +1100,7 @@ def test_integration_group_not_found_error(
     openreview_client = openreview_context["openreview_client"]
     test_client = openreview_context["test_client"]
 
-    conference_id = "NIPS.cc/2029/Conference"
+    conference_id = "NIPS.cc/2030/Conference"
     num_reviewers = 10
     num_papers = 10
     reviews_per_paper = 3
@@ -1144,7 +1144,7 @@ def test_integration_group_not_found_error(
         "custom_max_papers_invitation": "{}/-/Custom_Max_Papers".format(
             reviewers_id
         ),
-        "match_group": "NIPS.cc/2029/Conference/NoReviewers",
+        "match_group": "NIPS.cc/2030/Conference/NoReviewers",
         "scores_specification": {
             conference.get_affinity_score_id(reviewers_id): {
                 "weight": 1.0,
@@ -1179,6 +1179,6 @@ def test_integration_group_not_found_error(
     matcher_status = wait_for_status(openreview_client, config_note.id)
     assert matcher_status.content["status"] == "Error"
     assert (
-        "Group Not Found: NIPS.cc/2029/Conference/NoReviewers"
+        "Group Not Found: NIPS.cc/2030/Conference/NoReviewers"
         in matcher_status.content["error_message"]
     )


### PR DESCRIPTION
- Allow this query `content.venueid=ICML.cc/2023/Conference/Submission`
- Allow deployment of assignments for the API 2 using a request form
- Fix tests