### PR TITLE
Add FairIR Matcher

### DIFF
--- a/matcher/__main__.py
+++ b/matcher/__main__.py
@@ -85,7 +85,7 @@ parser.add_argument(
 # TODO: can argparse throw an error if the solver isn't in the list?
 parser.add_argument(
     "--solver",
-    help="Choose from: {}".format(["MinMax", "FairFlow", "Randomized"]),
+    help="Choose from: {}".format(["MinMax", "FairFlow", "Randomized", "FairIR"]),
     default="MinMax",
 )
 
@@ -100,6 +100,8 @@ if args.solver == "FairFlow":
     solver_class = "FairFlow"
 if args.solver == "Randomized":
     solver_class = "Randomized"
+if args.solver == "FairIR":
+    solver_class = "FairIR"
 
 if not solver_class:
     raise ValueError("Invalid solver class {}".format(args.solver))

--- a/matcher/__main__.py
+++ b/matcher/__main__.py
@@ -89,6 +89,11 @@ parser.add_argument(
     default="MinMax",
 )
 
+parser.add_argument(
+    "--attribute_constraints",
+    help="""JSON file with attribute constraints"""
+)
+
 args = parser.parse_args()
 
 # Main Logic
@@ -225,6 +230,11 @@ if args.probability_limits:
                 + ", ".join(missing_papers)
             )
 
+attr_constraints = None
+if args.attribute_constraints:
+    with open(args.attribute_constraints) as file_handle:
+        attr_constraints = json.load(file_handle)
+
 
 logger.info("Count of reviewers={} ".format(len(reviewers)))
 logger.info("Count of papers={}".format(len(papers)))
@@ -241,6 +251,7 @@ match_data = {
     "probability_limits": probability_limits,
     "num_alternates": num_alternates,
     "allow_zero_score_assignments": args.allow_zero_score_assignments,
+    "attribute_constraints": attr_constraints,
     "assignments_output": "assignments.json",
     "alternates_output": "alternates.json",
     "logger": logger,

--- a/matcher/core.py
+++ b/matcher/core.py
@@ -55,6 +55,7 @@ class KeywordDatasource:
         num_alternates=0,
         probability_limits=[],
         allow_zero_score_assignments=False,
+        attribute_constraints=None,
         assignments_output="assignments.json",
         alternates_output="alternates.json",
         logger=logging.getLogger(__name__),
@@ -71,6 +72,7 @@ class KeywordDatasource:
         self.probability_limits = probability_limits
         self.num_alternates = num_alternates
         self.allow_zero_score_assignments = allow_zero_score_assignments
+        self.attribute_constraints = attribute_constraints
         self.normalization_types = []
         self.assignments_output = assignments_output
         self.alternates_output = alternates_output
@@ -158,6 +160,7 @@ class Matcher:
                 weight_by_type=self.datasource.weight_by_type,
                 normalization_types=self.datasource.normalization_types,
                 probability_limits=self.datasource.probability_limits,
+                attribute_constraints=self.datasource.attribute_constraints,
                 logger=self.logger,
             )
 

--- a/matcher/core.py
+++ b/matcher/core.py
@@ -151,6 +151,8 @@ class Matcher:
             self.set_status(MatcherStatus.RUNNING)
 
             self.logger.debug("Start encoding")
+            self.logger.debug(self.datasource.constraints)
+            self.logger.debug(self.datasource.attribute_constraints)
 
             encoder = Encoder(
                 reviewers=self.datasource.reviewers,

--- a/matcher/core.py
+++ b/matcher/core.py
@@ -10,6 +10,7 @@ from .solvers import (
     FairFlow,
     RandomizedSolver,
     FairSequence,
+    FairIR
 )
 from .encoder import Encoder
 
@@ -18,6 +19,7 @@ SOLVER_MAP = {
     "FairFlow": FairFlow,
     "Randomized": RandomizedSolver,
     "FairSequence": FairSequence,
+    "FairIR": FairIR
 }
 
 

--- a/matcher/core.py
+++ b/matcher/core.py
@@ -151,8 +151,6 @@ class Matcher:
             self.set_status(MatcherStatus.RUNNING)
 
             self.logger.debug("Start encoding")
-            self.logger.debug(self.datasource.constraints)
-            self.logger.debug(self.datasource.attribute_constraints)
 
             encoder = Encoder(
                 reviewers=self.datasource.reviewers,

--- a/matcher/encoder.py
+++ b/matcher/encoder.py
@@ -125,7 +125,6 @@ class Encoder:
                     'bound': constraint_dict['bound'],
                     'members': members
                 })
-        self.logger.debug(f"Parsed attribute constraints: {constraints_list}")
         self.attribute_constraints = constraints_list
 
         # don't use numpy.sum() here. it will collapse the matrices into a single value.

--- a/matcher/encoder.py
+++ b/matcher/encoder.py
@@ -124,7 +124,7 @@ class Encoder:
                 try:
                     members = [self.index_by_user[member] for member in constraint_dict['members']]
                 except Exception as e:
-                    raise EncoderError(f"Not all members are in the reviewers")
+                    raise EncoderError(f"Not all {name} members are in the reviewers")
                 constraints_list.append({
                     'name': name,
                     'comparator': constraint_dict['comparator'],

--- a/matcher/encoder.py
+++ b/matcher/encoder.py
@@ -111,18 +111,20 @@ class Encoder:
         )
 
         # Parse attribute constraints -> reviewers to indices
-        constraints_list = []
-        for name, constraint_dict in attribute_constraints.items():
-            try:
-                members = [self.index_by_user[member] for member in constraint_dict['members']]
-            except Exception as e:
-                raise EncoderError(f"Not all members are in the reviewers")
-            constraints_list.append({
-                'name': name,
-                'comparator': constraint_dict['comparator'],
-                'bound': constraint_dict['bound'],
-                'members': members
-            })
+        constraints_list = None
+        if attribute_constraints:
+            constraints_list = []
+            for name, constraint_dict in attribute_constraints.items():
+                try:
+                    members = [self.index_by_user[member] for member in constraint_dict['members']]
+                except Exception as e:
+                    raise EncoderError(f"Not all members are in the reviewers")
+                constraints_list.append({
+                    'name': name,
+                    'comparator': constraint_dict['comparator'],
+                    'bound': constraint_dict['bound'],
+                    'members': members
+                })
         self.logger.debug(f"Parsed attribute constraints: {constraints_list}")
         self.attribute_constraints = constraints_list
 

--- a/matcher/encoder.py
+++ b/matcher/encoder.py
@@ -91,6 +91,7 @@ class Encoder:
 
         self.matrix_shape = (len(self.papers), len(self.reviewers))
 
+        self.logger.debug("Init score matrices")
         self.score_matrices = {
             score_type: self._encode_scores(scores)
             for score_type, scores in scores_by_type.items()
@@ -99,20 +100,25 @@ class Encoder:
         with_normalization_matrices = {}
         without_normalization_matrices = {}
 
+        self.logger.debug("Init normalization matricies")
         for score_type, scores in self.score_matrices.items():
             if score_type in normalization_types:
                 with_normalization_matrices[score_type] = scores
             else:
                 without_normalization_matrices[score_type] = scores
 
+        self.logger.debug("Init conflicts")
         self.constraint_matrix = self._encode_constraints(constraints)
         self.prob_limit_matrix = self._encode_probability_limits(
             probability_limits
         )
 
         # Parse attribute constraints -> reviewers to indices
+        self.logger.debug("Init attribute constraints")
         constraints_list = None
         if attribute_constraints:
+            self.logger.debug("Attribute constraints detected")
+            self.logger.debug(attribute_constraints)
             constraints_list = []
             for name, constraint_dict in attribute_constraints.items():
                 try:

--- a/matcher/encoder.py
+++ b/matcher/encoder.py
@@ -118,7 +118,6 @@ class Encoder:
         constraints_list = None
         if attribute_constraints:
             self.logger.debug("Attribute constraints detected")
-            self.logger.debug(attribute_constraints)
             constraints_list = []
             for name, constraint_dict in attribute_constraints.items():
                 try:

--- a/matcher/service/openreview_interface.py
+++ b/matcher/service/openreview_interface.py
@@ -463,17 +463,11 @@ class BaseConfigNoteInterface:
         self.logger.debug(
             "GET grouped edges invitation id={}".format(edge_invitation_id)
         )
-        self.logger.debug(
-            edges_grouped_by_paper
-        )
         filtered_edges_groups = list(
             filter(
                 lambda edge_group: edge_group["id"]["head"] in all_papers,
                 edges_grouped_by_paper,
             )
-        )
-        self.logger.debug(
-            filtered_edges_groups
         )
 
         for group in filtered_edges_groups:
@@ -568,8 +562,6 @@ class ConfigNoteInterfaceV1(BaseConfigNoteInterface):
         self.probability_limits = float(
             self.config_note.content.get("randomized_probability_limits", 1.0)
         )
-
-        # self.attribute_constraints = self.config_note.content.get('attribute_constraints', None)
 
         # Lazy variables
         self._reviewers = None
@@ -769,8 +761,6 @@ class ConfigNoteInterfaceV2(BaseConfigNoteInterface):
         self.probability_limits = float(
             self.config_note.content.get("randomized_probability_limits", 1.0)
         )
-
-        # self.attribute_constraints = self.config_note.content.get('attribute_constraints', None)
 
         # Lazy variables
         self._reviewers = None

--- a/matcher/service/openreview_interface.py
+++ b/matcher/service/openreview_interface.py
@@ -468,6 +468,8 @@ class ConfigNoteInterfaceV1(BaseConfigNoteInterface):
             self.config_note.content.get("randomized_probability_limits", 1.0)
         )
 
+        self.attribute_constraints = self.config_note.content.get('attribute_constraints', None)
+
         # Lazy variables
         self._reviewers = None
         self._papers = None
@@ -662,6 +664,8 @@ class ConfigNoteInterfaceV2(BaseConfigNoteInterface):
         self.probability_limits = float(
             self.config_note.content.get("randomized_probability_limits", 1.0)
         )
+
+        self.attribute_constraints = self.config_note.content.get('attribute_constraints', None)
 
         # Lazy variables
         self._reviewers = None

--- a/matcher/solvers/__init__.py
+++ b/matcher/solvers/__init__.py
@@ -6,3 +6,4 @@ from .simple_solver import SimpleSolver
 from .randomized_solver import RandomizedSolver
 from .fairflow import FairFlow
 from .fairsequence import FairSequence
+from .fairir import FairIR

--- a/matcher/solvers/basic_gurobi.py
+++ b/matcher/solvers/basic_gurobi.py
@@ -1,0 +1,132 @@
+import numpy as np
+import time
+import uuid
+import argparse
+
+from gurobipy import *
+
+
+class Basic(object):
+    """Paper matching formulated as a linear program."""
+    def __init__(self, loads, coverages, weights, country = None, institute = None, conflict = None, loads_lb=None):
+        """Initialize the Basic matcher
+        Args:
+            loads - a list of integers specifying the maximum number of papers
+                  for each reviewer.
+            coverages - a list of integers specifying the number of reviews per
+                 paper.
+            weights - the affinity matrix (np.array) of papers to reviewers.
+                   Rows correspond to reviewers and columns correspond to
+                   papers.
+            loads_lb - a list of integers specifying the min number of papers
+                  for each reviewer (optional).
+        Returns:
+            initialized matcher.
+        """
+        self.n_rev = np.size(weights, axis=0)
+        self.n_pap = np.size(weights, axis=1)
+        self.loads = loads
+        self.loads_lb = loads_lb
+        self.coverages = coverages
+
+        assert(np.sum(coverages) <= np.sum(loads))
+        if loads_lb is not None:
+            assert(np.sum(coverages) >= np.sum(loads_lb))
+
+        self.weights = weights
+        self.id = uuid.uuid4()
+        self.m = Model("%s: basic matcher" % str(self.id))
+        self.solution = None
+        self.m.setParam('OutputFlag', 0)
+
+        # Primal vars.
+        start = time.time()
+        coeff = list(self.weights.flatten())
+        print('#info Basic:flatten %s' % (time.time() - start))
+        self.lp_vars = self.m.addVars(self.n_rev, self.n_pap, vtype=GRB.BINARY,
+                                      name='x', obj=coeff)
+        self.m.update()
+        print('#info Basic:Time to add vars %s' % (time.time() - start))
+
+        # Objective.
+        self.m.setObjective(self.m.getObjective(), GRB.MAXIMIZE)
+        self.m.update()
+
+        # Constraints.
+        start = time.time()
+        self.m.addConstrs((self.lp_vars.sum(r, '*') <= l
+                           for r, l in enumerate(self.loads)), name='p')
+        self.m.addConstrs((self.lp_vars.sum('*', p) == c
+                           for p, c in enumerate(self.coverages)), name='r')
+        if conflict is not None:
+            self.m.addConstrs((self.lp_vars[i,j] == 0 for i in range(self.n_rev) for j in range(self.n_pap) if conflict[i,j] == 1), name="conflict")
+        if institute is not None:
+            self.m.addConstrs((self.lp_vars.sum(institute[i], j) <= 1 for j in range(self.n_pap) for i in range(len(institute))), name="inst")
+        if country is not None:
+            self.m.addConstrs(
+                (self.lp_vars.sum(country[i], j) <= 1 for j in range(self.n_pap) for i in range(len(country))),name="country")
+
+        if self.loads_lb is not None:
+            self.m.addConstrs((self.lp_vars.sum(r, '*') >= l
+                               for r, l in enumerate(self.loads_lb)))
+
+        self.m.update()
+        print('#info Basic:Time to add constraints %s' % (time.time() - start))
+
+    @staticmethod
+    def var_name(i, j):
+        """The name of the variable corresponding to reviewer i and paper j."""
+        return "x_" + str(i) + "," + str(j)
+
+    @staticmethod
+    def indices_of_var(v):
+        """Get the indices associated with a particular var_name (above)."""
+        name = v.varName
+        indices = name[2:].split(',')
+        i, j = int(indices[0]), int(indices[1])
+        return i, j
+
+    def solve(self):
+        """Solve the ILP.
+        If we were not able to solve the ILP optimally or suboptimally, then
+        raise an error.  If we are able to solve the ILP, save the solution.
+        Args:
+            None.
+        Returns:
+            An np array corresponding to the solution.
+        """
+        self.m.optimize()
+        if self.m.status == GRB.OPTIMAL:
+            self.solution = self.sol_as_mat()
+        if self.m.status == GRB.INFEASIBLE:
+            print ("INFEASIBLE")
+            vars = self.m.getVars()
+            ubpen = [1.0] * self.m.numVars
+            constraints = [const for const in self.m.getConstrs() if "country" in const.ConstrName or "inst" in const.ConstrName]
+            rhspen = [1.0] * len(constraints)
+            self.m.feasRelax(1, False, vars, None, ubpen, constraints, rhspen)
+            self.m.optimize()
+            self.solution = self.sol_as_mat()
+        return self.solution
+
+    def sol_as_mat(self):
+        if self.m.status == GRB.OPTIMAL:
+            if self.solution is None:
+                self.solution = np.zeros((self.n_rev, self.n_pap))
+            for key, var in self.lp_vars.items():
+                self.solution[key[0], key[1]] = var.x
+            return self.solution
+        else:
+            raise Exception('Must solve the model optimally before calling!')
+
+    def status(self):
+        """Return the status code of the solver."""
+        return self.m.status
+
+    def turn_on_verbosity(self):
+        """Turn on vurbosity for debugging."""
+        self.m.setParam('OutputFlag', 1)
+
+    def objective_val(self):
+        """Get the objective value of a solved lp."""
+        return self.m.ObjVal

--- a/matcher/solvers/fairir.py
+++ b/matcher/solvers/fairir.py
@@ -1,0 +1,328 @@
+import numpy as np
+import time
+import uuid
+
+from .basic_gurobi import Basic
+from gurobipy import *
+
+
+class FairIR(Basic):
+    """Fair paper matcher via iterative relaxation.
+
+    """
+
+    def __init__(self, loads, loads_lb, coverages, weights, thresh=0.0):
+        """Initialize.
+
+        Args:
+            loads - a list of integers specifying the maximum number of papers
+                  for each reviewer.
+            loads_lb - a list of ints specifying the minimum number of papers
+                  for each reviewer.
+            coverages - a list of integers specifying the number of reviews per
+                 paper.
+            weights - the affinity matrix (np.array) of papers to reviewers.
+                   Rows correspond to reviewers and columns correspond to
+                   papers.
+
+            Returns:
+                initialized makespan matcher.
+        """
+        self.n_rev = np.size(weights, axis=0)
+        self.n_pap = np.size(weights, axis=1)
+        self.loads = loads
+        self.loads_lb = loads_lb
+        self.coverages = coverages
+        self.weights = weights
+        self.id = uuid.uuid4()
+        self.m = Model("%s : FairIR" % str(self.id))
+        self.makespan = thresh
+        self.solution = None
+
+        self.m.setParam('OutputFlag', 0)
+
+        self.load_ub_name = 'lib'
+        self.load_lb_name = 'llb'
+        self.cov_name = 'cov'
+        self.ms_constr_prefix = 'ms'
+        self.round_constr_prefix = 'round'
+
+        # primal variables
+        start = time.time()
+        self.lp_vars = []
+        for i in range(self.n_rev):
+            self.lp_vars.append([])
+            for j in range(self.n_pap):
+                self.lp_vars[i].append(self.m.addVar(ub=1.0,
+                                                     name=self.var_name(i, j)))
+        self.m.update()
+        print('#info FairIR:Time to add vars %s' % (time.time() - start))
+
+        start = time.time()
+        # set the objective
+        obj = LinExpr()
+        for i in range(self.n_rev):
+            for j in range(self.n_pap):
+                obj += self.weights[i][j] * self.lp_vars[i][j]
+        self.m.setObjective(obj, GRB.MAXIMIZE)
+        print('#info FairIR:Time to set obj %s' % (time.time() - start))
+
+        start = time.time()
+        # load upper bound constraints.
+        for r, load in enumerate(self.loads):
+            self.m.addConstr(sum(self.lp_vars[r]) <= load,
+                             self.lub_constr_name(r))
+
+        # load load bound constraints.
+        if self.loads_lb is not None:
+            for r, load in enumerate(self.loads_lb):
+                self.m.addConstr(sum(self.lp_vars[r]) >= load,
+                                 self.llb_constr_name(r))
+
+        # coverage constraints.
+        for p, cov in enumerate(self.coverages):
+            self.m.addConstr(sum([self.lp_vars[i][p]
+                                  for i in range(self.n_rev)]) == cov,
+                             self.cov_constr_name(p))
+
+        # makespan constraints.
+        for p in range(self.n_pap):
+            self.m.addConstr(sum([self.lp_vars[i][p] * self.weights[i][p]
+                                  for i in range(self.n_rev)]) >= self.makespan,
+                             self.ms_constr_name(p))
+        self.m.update()
+        print('#info FairIR:Time to add constr %s' % (time.time() - start))
+
+    def ms_constr_name(self, p):
+        """Name of the makespan constraint for paper p."""
+        return '%s%s' % (self.ms_constr_prefix, p)
+
+    def lub_constr_name(self, r):
+        """Name of load upper bound constraint for reviewer r."""
+        return '%s%s' % (self.load_ub_name, r)
+
+    def llb_constr_name(self, r):
+        """Name of load lower bound constraint for reviewer r."""
+        return '%s%s' % (self.load_lb_name, r)
+
+    def cov_constr_name(self, p):
+        """Name of coverage constraint for paper p."""
+        return '%s%s' % (self.cov_name, p)
+
+    def change_makespan(self, new_makespan):
+        """Change the current makespan to a new_makespan value.
+
+        Args:
+            new_makespan - the new makespan constraint.
+
+        Returns:
+            Nothing.
+        """
+        for c in self.m.getConstrs():
+            if c.getAttr("ConstrName").startswith(self.ms_constr_prefix):
+                self.m.remove(c)
+                # self.m.update()
+
+        for p in range(self.n_pap):
+            self.m.addConstr(sum([self.lp_vars[i][p] * self.weights[i][p]
+                                  for i in range(self.n_rev)]) >= new_makespan,
+                             self.ms_constr_prefix + str(p))
+        self.makespan = new_makespan
+        self.m.update()
+
+    def sol_as_mat(self):
+        if self.m.status == GRB.OPTIMAL or self.m.status == GRB.SUBOPTIMAL:
+            solution = np.zeros((self.n_rev, self.n_pap))
+            for v in self.m.getVars():
+                i, j = self.indices_of_var(v)
+                solution[i, j] = v.x
+            self.solution = solution
+            return solution
+        else:
+            raise Exception(
+                'You must have solved the model optimally or suboptimally '
+                'before calling this function.')
+
+    def integral_sol_found(self):
+        """Return true if all lp variables are integral."""
+        sol = self.sol_as_dict()
+        return all(sol[self.var_name(i, j)] == 1.0 or
+                   sol[self.var_name(i, j)] == 0.0
+                   for i in range(self.n_rev) for j in range(self.n_pap))
+
+    def fix_assignment(self, i, j, val):
+        """Round the variable x_ij to val."""
+        self.lp_vars[i][j].ub = val
+        self.lp_vars[i][j].lb = val
+
+    def find_ms(self):
+        """Find an the highest possible makespan.
+
+        Perform a binary search on the makespan value. Each time, solve the
+        makespan LP without the integrality constraint. If we can find a
+        fractional value to one of these LPs, then we can round it.
+
+        Args:
+            None
+
+        Return:
+            Highest feasible makespan value found.
+        """
+        mn = 0.0
+        mx = np.max(self.weights) * np.max(self.coverages)
+        ms = mx
+        best = None
+        self.change_makespan(ms)
+        start = time.time()
+        self.m.optimize()
+        print('#info FairIR:Time to solve %s' % (time.time() - start))
+        for i in range(10):
+            print('#info FairIR:ITERATION %s ms %s' % (i, ms))
+            if self.m.status == GRB.INFEASIBLE:
+                mx = ms
+                ms -= (ms - mn) / 2.0
+            else:
+                assert(best is None or ms > best)
+                assert(self.m.status == GRB.OPTIMAL)
+                best = ms
+                mn = ms
+                ms += (mx - ms) / 2.0
+            self.change_makespan(ms)
+            self.m.optimize()
+        return best
+
+    def solve(self):
+        """Find a makespan and solve the ILP.
+
+        Run a binary search to find an appropriate makespan and then solve the
+        ILP. If solved optimally or suboptimally then save the solution.
+
+        Args:
+            mn - the minimum feasible makespan (optional).
+            mx - the maximum possible makespan( optional).
+            itr - the number of iterations of binary search for the makespan.
+            log_file - the string path to the log file.
+
+        Returns:
+            The solution as a matrix.
+        """
+        if self.makespan <= 0:
+            print('#info FairIR: searching for fairness threshold')
+            ms = self.find_ms()
+        else:
+            print('#info FairIR: config fairness threshold: %s' % self.makespan)
+            ms = self.makespan
+        self.change_makespan(ms)
+        self.round_fractional(np.ones((self.n_rev, self.n_pap)) * -1)
+
+        sol = {}
+        for v in self.m.getVars():
+            sol[v.varName] = v.x
+
+    def sol_as_dict(self):
+        """Return the solution to the optimization as a dictionary.
+
+        If the matching has not be solved optimally or suboptimally, then raise
+        an exception.
+
+        Args:
+            None.
+
+        Returns:
+            A dictionary from var_name to value (either 0 or 1)
+        """
+        if self.m.status == GRB.OPTIMAL or self.m.status == GRB.SUBOPTIMAL:
+            _sol = {}
+            for v in self.m.getVars():
+                _sol[v.varName] = v.x
+            return _sol
+        else:
+            raise Exception(
+                'You must have solved the model optimally or suboptimally '
+                'before calling this function.\nSTATUS %s\tMAKESPAN %f' % (
+                    self.m.status, self.makespan))
+
+    def round_fractional(self, integral_assignments=None, count=0):
+        """Round a fractional solution.
+
+        This is the meat of the iterative relaxation approach.  First, if the
+        solution to the relaxed LP is integral, then we're done--return the
+        solution. Otherwise, here's what we do:
+        1. if a variable is integral, lock it's value to that integer.
+        2. find all papers with exactly 2 or 3 fractionally assigned revs and
+           drop the makespan constraint on that reviewer.
+        3. if no makespan constraints dropped, find a reviewer with exactly two
+           fraction assignments and drop the load constraints on that reviewer.
+
+        Args:
+            integral_assignments - np.array of revs x paps (initially None).
+            log_file - the log file if exists.
+            count - (int) to keep track of the number of calls to this function.
+
+        Returns:
+            Nothing--has the side effect or storing an assignment matrix in this
+            class.
+        """
+        if integral_assignments is None:
+            integral_assignments = np.ones((self.n_rev, self.n_pap)) * -1
+
+        self.m.optimize()
+
+        if self.m.status != GRB.OPTIMAL and self.m.status != GRB.SUBOPTIMAL:
+            assert False, '%s\t%s' % (self.m.status, self.makespan)
+
+        if self.integral_sol_found():
+            return
+        else:
+            frac_assign_p = {}
+            frac_assign_r = {}
+            sol = self.sol_as_dict()
+            fractional_vars = []
+
+            # Find fractional vars.
+            for i in range(self.n_rev):
+                for j in range(self.n_pap):
+                    if j not in frac_assign_p:
+                        frac_assign_p[j] = []
+                    if i not in frac_assign_r:
+                        frac_assign_r[i] = []
+
+                    if sol[self.var_name(i, j)] == 0.0 and \
+                                    integral_assignments[i][j] != 0.0:
+                        self.fix_assignment(i, j, 0.0)
+                        integral_assignments[i][j] = 0.0
+
+                    elif sol[self.var_name(i, j)] == 1.0 and \
+                                    integral_assignments[i][j] != 1.0:
+                        self.fix_assignment(i, j, 1.0)
+                        integral_assignments[i][j] = 1.0
+
+                    elif sol[self.var_name(i, j)] != 1.0 and \
+                                    sol[self.var_name(i, j)] != 0.0:
+                        frac_assign_p[j].append(
+                            (i, j, sol[self.var_name(i, j)]))
+                        frac_assign_r[i].append(
+                            (i, j, sol[self.var_name(i, j)]))
+                        fractional_vars.append((i, j, sol[self.var_name(i, j)]))
+
+                        integral_assignments[i][j] = sol[self.var_name(i, j)]
+
+            # First try to elim a makespan constraint.
+            removed = False
+            for (paper, frac_vars) in frac_assign_p.items():
+                if len(frac_vars) == 2 or len(frac_vars) == 3:
+                    for c in self.m.getConstrs():
+                        if c.ConstrName == self.ms_constr_name(paper):
+                            self.m.remove(c)
+                            removed = True
+
+            # If necessary remove a load constraint.
+            if not removed:
+                for (rev, frac_vars) in frac_assign_r.items():
+                    if len(frac_vars) == 2:
+                        for c in self.m.getConstrs():
+                            if c.ConstrName == self.lub_constr_name(rev) or \
+                                    c.ConstrName == self.llb_constr_name(rev):
+                                self.m.remove(c)
+            self.m.update()
+            return self.round_fractional(integral_assignments, count + 1)

--- a/matcher/solvers/fairir.py
+++ b/matcher/solvers/fairir.py
@@ -192,6 +192,29 @@ class FairIR(Basic):
         self.m.update()
         print('#info FairIR:Time to add constr %s' % (time.time() - start))
 
+    def _validate_input_range(self):
+        """Validate if demand is in the range of min supply and max supply"""
+        self.logger.debug("Checking if demand is in range")
+
+        min_supply = sum(self.loads_lb)
+        max_supply = sum(self.loads)
+        demand = sum(self.coverages)
+
+        self.logger.debug(
+            "Total demand is ({}), min review supply is ({}), and max review supply is ({})".format(
+                demand, min_supply, max_supply
+            )
+        )
+
+        if demand > max_supply or demand < min_supply:
+            raise SolverException(
+                "Total demand ({}) is out of range when min review supply is ({}) and max review supply is ({})".format(
+                    demand, min_supply, max_supply
+                )
+            )
+
+        self.logger.debug("Finished checking graph inputs")
+
     def attr_constr_name(self, n, p):
         """Name of the makespan constraint for paper p."""
         return '%s%s' % (n, p)
@@ -357,6 +380,7 @@ class FairIR(Basic):
         Returns:
             The solution as a matrix.
         """
+        self._validate_input_range()
         if self.makespan <= 0:
             print('#info FairIR: searching for fairness threshold')
             ms = self.find_ms()

--- a/matcher/solvers/fairir.py
+++ b/matcher/solvers/fairir.py
@@ -445,6 +445,7 @@ class FairIR(Basic):
 
             # Find fractional vars.
             for i in range(self.n_rev):
+                print(f'#info FairIR:ROUND_FRACTIONAL O(RP) loop target=reviewer{i}')
                 for j in range(self.n_pap):
                     if j not in frac_assign_p:
                         frac_assign_p[j] = []
@@ -467,6 +468,8 @@ class FairIR(Basic):
 
                         fractional_vars.append((i, j, sol[self.var_name(i, j)]))
                         integral_assignments[i][j] = sol[self.var_name(i, j)]
+                
+            print('#info FairIR:ROUND_FRACTIONAL END O(RP) loop ')
 
             # First try to elim a makespan constraint.
             removed = False

--- a/matcher/solvers/fairir.py
+++ b/matcher/solvers/fairir.py
@@ -299,7 +299,7 @@ class FairIR(Basic):
                 mx = ms
                 ms -= (ms - mn) / 2.0
             else:
-                assert(best is None or ms > best)
+                assert(best is None or ms >= best)
                 assert(self.m.status == GRB.OPTIMAL)
                 best = ms
                 mn = ms

--- a/matcher/solvers/fairir.py
+++ b/matcher/solvers/fairir.py
@@ -453,10 +453,14 @@ class FairIR(Basic):
                         frac_assign_r[i] = []
 
                     if sol[self.var_name(i, j)] == 0.0 and integral_assignments[i][j] != 0.0:
-                        self.fix_assignment_to_zero_with_constraints(i, j, integral_assignments)
+                        #self.fix_assignment_to_zero_with_constraints(i, j, integral_assignments)
+                        self.fix_assignment(i, j, 0.0)
+                        integral_assignments[i][j] = 0.0
 
                     elif sol[self.var_name(i, j)] == 1.0 and integral_assignments[i][j] != 1.0:
-                        self.fix_assignment_to_one_with_constraints(i, j, integral_assignments)
+                        #self.fix_assignment_to_one_with_constraints(i, j, integral_assignments)
+                        self.fix_assignment(i, j, 1.0)
+                        integral_assignments[i][j] = 1.0
 
                     elif sol[self.var_name(i, j)] != 1.0 and sol[self.var_name(i, j)] != 0.0:
                         frac_assign_p[j].append(

--- a/matcher/solvers/fairir.py
+++ b/matcher/solvers/fairir.py
@@ -222,10 +222,10 @@ class FairIR(Basic):
                 'You must have solved the model optimally or suboptimally '
                 'before calling this function.')
 
-    def integral_sol_found(self):
+    def integral_sol_found(self, precalculated=None):
         print('#info FairIR:INTEGRAL_SOL_FOUND call')
         """Return true if all lp variables are integral."""
-        sol = self.sol_as_dict()
+        sol = self.sol_as_dict() if precalculated is None else precalculated
         return all(sol[self.var_name(i, j)] == 1.0 or
                    sol[self.var_name(i, j)] == 0.0
                    for i in range(self.n_rev) for j in range(self.n_pap))
@@ -436,12 +436,11 @@ class FairIR(Basic):
                                 f"Paper {p} has violated {name} constraint. Expected: {bound} Found: {s}\nValues: {[sol[self.var_name(i, p)] for i in members]}"
                             )
 
-        if self.integral_sol_found():
+        if self.integral_sol_found(precalculated=sol):
             return
         else:
             frac_assign_p = {}
             frac_assign_r = {}
-            sol = self.sol_as_dict()
             fractional_vars = []
 
             # Find fractional vars.

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,8 @@ setup(
         "MarkupSafe==2.*",
         "gunicorn==19.*",
         "importlib-metadata>=1.1.0,<4.3",
-        "flake8==3.8.4"
+        "flake8==3.8.4",
+        "gurobipy==10.0.1"
     ],
     extras_require={
         "full": ["flower"],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -296,15 +296,17 @@ def clean_start_conference(
         affinity_score_file=AFFINITY_SCORE_FILE, build_conflicts=True
     )
 
+    return conference
+
+def post_fairir_to_api1(
+    client, conference_id
+):
     # Update conftest to manually include the FairIR matcher and a constraints spec
     # To be added to openreview-py if we can support Gurobi in the matcher
     inv = client.get_invitation(f"{conference_id}/Reviewers/-/Assignment_Configuration")
     inv.reply['content']['solver']['value-radio'].append('FairIR')
     inv.reply['content']['constraints_specification'] = inv.reply['content']['scores_specification']
     client.post_invitation(inv)
-
-    return conference
-
 
 def assert_arrays(array_A, array_B, is_string=False):
     if is_string:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -303,7 +303,8 @@ def post_fairir_to_api2(
 ):
     inv = client.get_invitation(f"{conference_id}/Reviewers/-/Assignment_Configuration")
     content = {
-        'solver': inv.edit['note']['content']['solver']
+        'solver': inv.edit['note']['content']['solver'],
+        'constraints_specification': inv.edit['note']['content']['scores_specification']
     }
     content['solver']['value']['param']['enum'].append('FairIR')
     inv.edit['note']['content'] = content

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -296,6 +296,13 @@ def clean_start_conference(
         affinity_score_file=AFFINITY_SCORE_FILE, build_conflicts=True
     )
 
+    # Update conftest to manually include the FairIR matcher and a constraints spec
+    # To be added to openreview-py if we can support Gurobi in the matcher
+    inv = client.get_invitation(f"{conference_id}/Reviewers/-/Assignment_Configuration")
+    inv.reply['content']['solver']['value-radio'].append('FairIR')
+    inv.reply['content']['constraints_specification'] = inv.reply['content']['scores_specification']
+    client.post_invitation(inv)
+
     return conference
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -298,6 +298,24 @@ def clean_start_conference(
 
     return conference
 
+def post_fairir_to_api2(
+    client, conference_id
+):
+    inv = client.get_invitation(f"{conference_id}/Reviewers/-/Assignment_Configuration")
+    content = {
+        'solver': inv.edit['note']['content']['solver']
+    }
+    content['solver']['value']['param']['enum'].append('FairIR')
+    inv.edit['note']['content'] = content
+    client.post_invitation_edit(
+        invitations=f"{conference_id}/-/Edit",
+        readers=[conference_id],
+        writers=[conference_id],
+        signatures=[conference_id],
+        replacement=False,
+        invitation=inv
+    )
+
 def post_fairir_to_api1(
     client, conference_id
 ):

--- a/tests/test_integration_api2_fairir.py
+++ b/tests/test_integration_api2_fairir.py
@@ -107,6 +107,162 @@ def test_integration_basic(openreview_context, celery_app, celery_worker):
 
     assert paper_assignment_edges == num_papers * reviews_per_paper
 
+def test_integration_attribute_constraints(
+    openreview_context, celery_app, celery_worker
+):
+    """
+    Basic integration test. Makes use of the OpenReview Builder
+    """
+    openreview_client = openreview_context["openreview_client_v2"]
+    test_client = openreview_context["test_client"]
+
+    conference_id = "IMCLR.ws/2017/Conference"
+    num_reviewers = 3
+    num_papers = 1
+    reviews_per_paper = 3
+    max_papers = 1
+    min_papers = 1
+    alternates = 0
+
+    venue = clean_start_conference_v2(
+        openreview_client,
+        conference_id,
+        num_reviewers,
+        num_papers,
+        reviews_per_paper,
+    )
+
+    post_fairir_to_api2(openreview_client, conference_id)
+
+    reviewers_id = venue.get_reviewers_id()
+    seniority_inv_id = "{}/-/Seniority".format(reviewers_id)
+
+    config = {
+        "title": {"value": "integration-test-constraints"},
+        "user_demand": {"value": str(reviews_per_paper)},
+        "max_papers": {"value": str(max_papers)},
+        "min_papers": {"value": str(min_papers)},
+        "alternates": {"value": str(alternates)},
+        "config_invitation": {
+            "value": "{}/-/Assignment_Configuration".format(reviewers_id)
+        },
+        "paper_invitation": {"value": venue.get_submission_id()},
+        "assignment_invitation": {
+            "value": venue.get_assignment_id(reviewers_id)
+        },
+        "deployed_assignment_invitation": {
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
+        },
+        "invite_assignment_invitation": {
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
+        },
+        "aggregate_score_invitation": {
+            "value": "{}/-/Aggregate_Score".format(reviewers_id)
+        },
+        "conflicts_invitation": {
+            "value": venue.get_conflict_score_id(reviewers_id)
+        },
+        "custom_max_papers_invitation": {
+            "value": "{}/-/Custom_Max_Papers".format(reviewers_id)
+        },
+        "match_group": {"value": reviewers_id},
+        "scores_specification": {
+            "value": {
+                venue.get_affinity_score_id(reviewers_id): {
+                    "weight": 1.0,
+                    "default": 0.0,
+                }
+            }
+        },
+        "constraints_specification": {
+            "value": {
+                seniority_inv_id: [
+                    { 
+                        "label": "Senior",
+                        "min_users": 1
+                    }
+                ]
+            }
+        },
+        "status": {"value": "Initialized"},
+        "solver": {"value": "FairIR"},
+    }
+    # Post Seniority edge invitation
+    venue_matching = openreview.venue.matching.Matching(venue, openreview_client.get_group(reviewers_id), None)
+    venue_matching._create_edge_invitation(seniority_inv_id)
+
+    inv = openreview_client.get_invitation(seniority_inv_id)
+    inv.edit['head'] = {
+        'param': {
+            'type': 'group',
+            'const': reviewers_id
+        }
+    }
+    openreview_client.post_invitation_edit(
+        invitations=f"{conference_id}/-/Edit",
+        readers=[conference_id],
+        writers=[conference_id],
+        signatures=[conference_id],
+        replacement=False,
+        invitation=inv
+    )
+
+    senior_reviewer = openreview_client.get_group(reviewers_id).members[0]
+    edge = openreview.api.Edge(
+        head=reviewers_id,
+        tail=senior_reviewer,
+        invitation=seniority_inv_id,
+        readers=venue_matching._get_edge_readers(reviewers_id),
+        writers=[venue.id],
+        signatures=[venue.id],
+        label='Senior',
+        weight=1
+    )
+
+    openreview.tools.post_bulk_edges(client=openreview_client, edges=[edge])
+
+    print(openreview_client.get_grouped_edges(invitation=seniority_inv_id, groupby='id'))
+
+    config_note = openreview_client.post_note_edit(
+        invitation="{}/-/Assignment_Configuration".format(reviewers_id),
+        signatures=[venue.get_id()],
+        note=Note(content=config),
+    )
+    assert config_note
+
+    response = test_client.post(
+        "/match",
+        data=json.dumps({"configNoteId": config_note["note"]["id"]}),
+        content_type="application/json",
+        headers=openreview_client.headers,
+    )
+    assert response.status_code == 200
+
+    matcher_status = wait_for_status(
+        openreview_client, config_note["note"]["id"], api_version=2
+    )
+    assert matcher_status.content["status"]["value"] == "Complete"
+
+    paper_assignment_edges = openreview_client.get_edges_count(
+        label="integration-test-constraints",
+        invitation=venue.get_assignment_id(venue.get_reviewers_id()),
+    )
+
+    assert paper_assignment_edges == num_papers * reviews_per_paper
+
+    grouped_edges = openreview_client.get_grouped_edges(
+        label="integration-test-constraints",
+        invitation=venue.get_assignment_id(
+            venue.get_reviewers_id()
+        ),
+        groupby='head',
+        select='id,head,tail'
+    )
+
+    for edge_dict in grouped_edges:
+        assert True in [senior_reviewer == edge['tail'] for edge in edge_dict['values']], f"No senior reviewer found"
+
+    assert paper_assignment_edges == num_papers * reviews_per_paper
 
 def test_integration_supply_mismatch_error(
     openreview_context, celery_app, celery_worker

--- a/tests/test_integration_api2_fairir.py
+++ b/tests/test_integration_api2_fairir.py
@@ -1,0 +1,1102 @@
+"""
+End-to-end integration tests with OpenReview server.
+"""
+
+import json
+
+import openreview
+from openreview.api import Note
+import pytest
+
+from conftest import clean_start_conference_v2, wait_for_status, post_fairir_to_api2
+
+
+def test_integration_basic(openreview_context, celery_app, celery_worker):
+    """
+    Basic integration test. Makes use of the OpenReview Builder
+    """
+
+    openreview_client = openreview_context["openreview_client_v2"]
+    test_client = openreview_context["test_client"]
+
+    conference_id = "IMCLR.ws/2019/Conference"
+    num_reviewers = 10
+    num_papers = 10
+    reviews_per_paper = 3
+    max_papers = 5
+    min_papers = 1
+    alternates = 0
+
+    venue = clean_start_conference_v2(
+        openreview_client,
+        conference_id,
+        num_reviewers,
+        num_papers,
+        reviews_per_paper,
+    )
+
+    post_fairir_to_api2(openreview_client, conference_id)
+
+    reviewers_id = venue.get_reviewers_id()
+
+    config = {
+        "title": {"value": "integration-test"},
+        "user_demand": {"value": str(reviews_per_paper)},
+        "max_papers": {"value": str(max_papers)},
+        "min_papers": {"value": str(min_papers)},
+        "alternates": {"value": str(alternates)},
+        "config_invitation": {
+            "value": "{}/-/Assignment_Configuration".format(reviewers_id)
+        },
+        "paper_invitation": {"value": venue.get_submission_id()},
+        "assignment_invitation": {
+            "value": venue.get_assignment_id(reviewers_id)
+        },
+        "deployed_assignment_invitation": {
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
+        },
+        "invite_assignment_invitation": {
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
+        },
+        "aggregate_score_invitation": {
+            "value": "{}/-/Aggregate_Score".format(reviewers_id)
+        },
+        "conflicts_invitation": {
+            "value": venue.get_conflict_score_id(reviewers_id)
+        },
+        "custom_max_papers_invitation": {
+            "value": "{}/-/Custom_Max_Papers".format(reviewers_id)
+        },
+        "match_group": {"value": reviewers_id},
+        "scores_specification": {
+            "value": {
+                venue.get_affinity_score_id(reviewers_id): {
+                    "weight": 1.0,
+                    "default": 0.0,
+                }
+            }
+        },
+        "status": {"value": "Initialized"},
+        "solver": {"value": "FairIR"},
+    }
+
+    config_note = openreview_client.post_note_edit(
+        invitation="{}/-/Assignment_Configuration".format(reviewers_id),
+        signatures=[venue.get_id()],
+        note=Note(content=config),
+    )
+    assert config_note
+
+    response = test_client.post(
+        "/match",
+        data=json.dumps({"configNoteId": config_note["note"]["id"]}),
+        content_type="application/json",
+        headers=openreview_client.headers,
+    )
+    assert response.status_code == 200
+
+    matcher_status = wait_for_status(
+        openreview_client, config_note["note"]["id"], api_version=2
+    )
+    assert matcher_status.content["status"]["value"] == "Complete"
+
+    paper_assignment_edges = openreview_client.get_edges_count(
+        label="integration-test",
+        invitation=venue.get_assignment_id(venue.get_reviewers_id()),
+    )
+
+    assert paper_assignment_edges == num_papers * reviews_per_paper
+
+
+def test_integration_supply_mismatch_error(
+    openreview_context, celery_app, celery_worker
+):
+    """
+    Basic integration test. Makes use of the OpenReview Builder
+    """
+    openreview_client = openreview_context["openreview_client_v2"]
+    test_client = openreview_context["test_client"]
+
+    conference_id = "IMCLR.ws/2030/Conference"
+    num_reviewers = 10
+    num_papers = 10
+    reviews_per_paper = 10  # impossible!
+    max_papers = 1
+    min_papers = 1
+    alternates = 0
+
+    venue = clean_start_conference_v2(
+        openreview_client,
+        conference_id,
+        num_reviewers,
+        num_papers,
+        reviews_per_paper,
+    )
+
+    post_fairir_to_api2(openreview_client, conference_id)
+
+    reviewers_id = venue.get_reviewers_id()
+
+    config = {
+        "title": {"value": "integration-test-2"},
+        "user_demand": {"value": str(reviews_per_paper)},
+        "max_papers": {"value": str(max_papers)},
+        "min_papers": {"value": str(min_papers)},
+        "alternates": {"value": str(alternates)},
+        "config_invitation": {
+            "value": "{}/-/Assignment_Configuration".format(reviewers_id)
+        },
+        "paper_invitation": {"value": venue.get_submission_id()},
+        "assignment_invitation": {
+            "value": venue.get_assignment_id(reviewers_id)
+        },
+        "deployed_assignment_invitation": {
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
+        },
+        "invite_assignment_invitation": {
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
+        },
+        "aggregate_score_invitation": {
+            "value": "{}/-/Aggregate_Score".format(reviewers_id)
+        },
+        "conflicts_invitation": {
+            "value": venue.get_conflict_score_id(reviewers_id)
+        },
+        "custom_max_papers_invitation": {
+            "value": "{}/-/Custom_Max_Papers".format(reviewers_id)
+        },
+        "match_group": {"value": reviewers_id},
+        "scores_specification": {
+            "value": {
+                venue.get_affinity_score_id(reviewers_id): {
+                    "weight": 1.0,
+                    "default": 0.0,
+                }
+            }
+        },
+        "status": {"value": "Initialized"},
+        "solver": {"value": "FairIR"},
+    }
+
+    config_note = openreview_client.post_note_edit(
+        invitation="{}/-/Assignment_Configuration".format(reviewers_id),
+        signatures=[venue.get_id()],
+        note=Note(content=config),
+    )
+    assert config_note
+
+    response = test_client.post(
+        "/match",
+        data=json.dumps({"configNoteId": config_note["note"]["id"]}),
+        content_type="application/json",
+        headers=openreview_client.headers,
+    )
+    assert response.status_code == 200
+
+    matcher_status = wait_for_status(
+        openreview_client, config_note["note"]["id"], api_version=2
+    )
+    assert matcher_status.content["status"]["value"] == "No Solution"
+    assert (
+        matcher_status.content["error_message"]["value"]
+        == "Total demand (100) is out of range when min review supply is (10) and max review supply is (10)"
+    )
+
+    paper_assignment_edges = openreview_client.get_edges_count(
+        label="integration-test-2",
+        invitation=venue.get_assignment_id(venue.get_reviewers_id()),
+    )
+
+    assert paper_assignment_edges == 0
+
+
+def test_integration_demand_out_of_supply_range_error(
+    openreview_context, celery_app, celery_worker
+):
+    """
+    Test to check that a No Solution is observed when demand is not in the range of min and max supply
+    """
+    openreview_client = openreview_context["openreview_client_v2"]
+    test_client = openreview_context["test_client"]
+
+    conference_id = "ICLSR.cc/2035/Conference"
+    num_reviewers = 10
+    num_papers = 10
+    reviews_per_paper = 3
+    max_papers = 5
+    min_papers = 4
+    alternates = 0
+
+    venue = clean_start_conference_v2(
+        openreview_client,
+        conference_id,
+        num_reviewers,
+        num_papers,
+        reviews_per_paper,
+    )
+
+    post_fairir_to_api2(openreview_client, conference_id)
+
+    reviewers_id = venue.get_reviewers_id()
+
+    config = {
+        "title": {"value": "integration-test"},
+        "user_demand": {"value": str(reviews_per_paper)},
+        "max_papers": {"value": str(max_papers)},
+        "min_papers": {"value": str(min_papers)},
+        "alternates": {"value": str(alternates)},
+        "config_invitation": {
+            "value": "{}/-/Assignment_Configuration".format(reviewers_id)
+        },
+        "paper_invitation": {"value": venue.get_submission_id()},
+        "assignment_invitation": {
+            "value": venue.get_assignment_id(reviewers_id)
+        },
+        "deployed_assignment_invitation": {
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
+        },
+        "invite_assignment_invitation": {
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
+        },
+        "aggregate_score_invitation": {
+            "value": "{}/-/Aggregate_Score".format(reviewers_id)
+        },
+        "conflicts_invitation": {
+            "value": venue.get_conflict_score_id(reviewers_id)
+        },
+        "custom_max_papers_invitation": {
+            "value": "{}/-/Custom_Max_Papers".format(reviewers_id)
+        },
+        "match_group": {"value": reviewers_id},
+        "scores_specification": {
+            "value": {
+                venue.get_affinity_score_id(reviewers_id): {
+                    "weight": 1.0,
+                    "default": 0.0,
+                }
+            }
+        },
+        "status": {"value": "Initialized"},
+        "solver": {"value": "FairIR"},
+    }
+
+    config_note = openreview_client.post_note_edit(
+        invitation="{}/-/Assignment_Configuration".format(reviewers_id),
+        signatures=[venue.get_id()],
+        note=Note(content=config),
+    )
+    assert config_note
+
+    response = test_client.post(
+        "/match",
+        data=json.dumps({"configNoteId": config_note["note"]["id"]}),
+        content_type="application/json",
+        headers=openreview_client.headers,
+    )
+    assert response.status_code == 200
+
+    matcher_status = wait_for_status(
+        openreview_client, config_note["note"]["id"], api_version=2
+    )
+    assert matcher_status.content["status"]["value"] == "No Solution"
+    assert (
+        matcher_status.content["error_message"]["value"]
+        == "Total demand (30) is out of range when min review supply is (40) and max review supply is (50)"
+    )
+
+    paper_assignment_edges = openreview_client.get_edges_count(
+        label="integration-test",
+        invitation=venue.get_assignment_id(venue.get_reviewers_id()),
+    )
+
+    assert paper_assignment_edges == 0
+
+
+def test_integration_no_scores(openreview_context, celery_app, celery_worker):
+    """
+    Basic integration test. Makes use of the OpenReview Builder
+    """
+    openreview_client = openreview_context["openreview_client_v2"]
+    test_client = openreview_context["test_client"]
+
+    conference_id = "IMCLR.ws/2020/Conference"
+    num_reviewers = 10
+    num_papers = 10
+    reviews_per_paper = 3
+    max_papers = 5
+    min_papers = 1
+    alternates = 0
+
+    venue = clean_start_conference_v2(
+        openreview_client,
+        conference_id,
+        num_reviewers,
+        num_papers,
+        reviews_per_paper,
+    )
+
+    post_fairir_to_api2(openreview_client, conference_id)
+
+    reviewers_id = venue.get_reviewers_id()
+
+    config = {
+        "title": {"value": "integration-test"},
+        "user_demand": {"value": str(reviews_per_paper)},
+        "max_papers": {"value": str(max_papers)},
+        "min_papers": {"value": str(min_papers)},
+        "alternates": {"value": str(alternates)},
+        "config_invitation": {
+            "value": "{}/-/Assignment_Configuration".format(reviewers_id)
+        },
+        "paper_invitation": {"value": venue.get_submission_id()},
+        "assignment_invitation": {
+            "value": venue.get_assignment_id(reviewers_id)
+        },
+        "deployed_assignment_invitation": {
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
+        },
+        "invite_assignment_invitation": {
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
+        },
+        "aggregate_score_invitation": {
+            "value": "{}/-/Aggregate_Score".format(reviewers_id)
+        },
+        "conflicts_invitation": {
+            "value": venue.get_conflict_score_id(reviewers_id)
+        },
+        "custom_max_papers_invitation": {
+            "value": "{}/-/Custom_Max_Papers".format(reviewers_id)
+        },
+        "match_group": {"value": reviewers_id},
+        "status": {"value": "Initialized"},
+        "solver": {"value": "FairIR"},
+        "allow_zero_score_assignments": {"value": "Yes"},
+    }
+
+    config_note = openreview_client.post_note_edit(
+        invitation="{}/-/Assignment_Configuration".format(reviewers_id),
+        signatures=[venue.get_id()],
+        note=Note(content=config),
+    )
+    assert config_note
+
+    response = test_client.post(
+        "/match",
+        data=json.dumps({"configNoteId": config_note["note"]["id"]}),
+        content_type="application/json",
+        headers=openreview_client.headers,
+    )
+    assert response.status_code == 200
+
+    matcher_status = wait_for_status(
+        openreview_client, config_note["note"]["id"], api_version=2
+    )
+
+    config_note = openreview_client.get_note(config_note["note"]["id"])
+    assert matcher_status.content["status"]["value"] == "Complete"
+
+    paper_assignment_edges = openreview_client.get_edges_count(
+        label="integration-test",
+        invitation=venue.get_assignment_id(venue.get_reviewers_id()),
+    )
+
+    assert paper_assignment_edges == num_papers * reviews_per_paper
+
+
+def test_routes_invalid_invitation(
+    openreview_context, celery_app, celery_worker
+):
+    """"""
+    openreview_client = openreview_context["openreview_client_v2"]
+    test_client = openreview_context["test_client"]
+
+    conference_id = "IMCLR.ws/2019/Conference"
+    num_reviewers = 10
+    num_papers = 10
+    reviews_per_paper = 3
+    max_papers = 5
+    min_papers = 1
+    alternates = 0
+
+    venue = clean_start_conference_v2(
+        openreview_client,
+        conference_id,
+        num_reviewers,
+        num_papers,
+        reviews_per_paper,
+    )
+
+    post_fairir_to_api2(openreview_client, conference_id)
+
+    reviewers_id = venue.get_reviewers_id()
+
+    config = {
+        "title": {"value": "integration-test"},
+        "user_demand": {"value": str(reviews_per_paper)},
+        "max_papers": {"value": str(max_papers)},
+        "min_papers": {"value": str(min_papers)},
+        "alternates": {"value": str(alternates)},
+        "config_invitation": {
+            "value": "{}/-/Assignment_Configuration".format(reviewers_id)
+        },
+        "paper_invitation": {"value": venue.get_submission_id()},
+        "assignment_invitation": {
+            "value": venue.get_assignment_id(reviewers_id)
+        },
+        "deployed_assignment_invitation": {
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
+        },
+        "invite_assignment_invitation": {
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
+        },
+        "aggregate_score_invitation": {
+            "value": "{}/-/Aggregate_Score".format(reviewers_id)
+        },
+        "conflicts_invitation": {
+            "value": venue.get_conflict_score_id(reviewers_id)
+        },
+        "custom_max_papers_invitation": {
+            "value": "{}/-/Custom_Max_Papers".format(reviewers_id)
+        },
+        "match_group": {"value": reviewers_id},
+        "scores_specification": {
+            "value": {
+                # conference.get_affinity_score_id(reviewers_id): {
+                #     'weight': 1.0,
+                #     'default': 0.0
+                # },
+                "<some_invalid_invitation>": {"weight": 1.0, "default": 0.0}
+            }
+        },
+        "status": {"value": "Initialized"},
+        "solver": {"value": "FairIR"},
+    }
+
+    config_note = openreview_client.post_note_edit(
+        invitation="{}/-/Assignment_Configuration".format(reviewers_id),
+        signatures=[venue.get_id()],
+        note=Note(content=config),
+    )
+    assert config_note
+
+    invalid_invitation_response = test_client.post(
+        "/match",
+        data=json.dumps({"configNoteId": config_note["note"]["id"]}),
+        content_type="application/json",
+        headers=openreview_client.headers,
+    )
+    assert invalid_invitation_response.status_code == 404
+
+    config_note = openreview_client.get_note(config_note["note"]["id"])
+    assert config_note.content["status"]["value"] == "Error"
+
+
+def test_routes_missing_header(openreview_context, celery_app, celery_worker):
+    """request with missing header should response with 400"""
+    openreview_client = openreview_context["openreview_client_v2"]
+    test_client = openreview_context["test_client"]
+
+    conference_id = "IMCLR.ws/2019/Conference"
+    num_reviewers = 10
+    num_papers = 10
+    reviews_per_paper = 3
+    max_papers = 5
+    min_papers = 1
+    alternates = 0
+
+    venue = clean_start_conference_v2(
+        openreview_client,
+        conference_id,
+        num_reviewers,
+        num_papers,
+        reviews_per_paper,
+    )
+
+    post_fairir_to_api2(openreview_client, conference_id)
+
+    reviewers_id = venue.get_reviewers_id()
+
+    config = {
+        "title": {"value": "integration-test"},
+        "user_demand": {"value": str(reviews_per_paper)},
+        "max_papers": {"value": str(max_papers)},
+        "min_papers": {"value": str(min_papers)},
+        "alternates": {"value": str(alternates)},
+        "config_invitation": {
+            "value": "{}/-/Assignment_Configuration".format(reviewers_id)
+        },
+        "paper_invitation": {"value": venue.get_submission_id()},
+        "assignment_invitation": {
+            "value": venue.get_assignment_id(reviewers_id)
+        },
+        "deployed_assignment_invitation": {
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
+        },
+        "invite_assignment_invitation": {
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
+        },
+        "aggregate_score_invitation": {
+            "value": "{}/-/Aggregate_Score".format(reviewers_id)
+        },
+        "conflicts_invitation": {
+            "value": venue.get_conflict_score_id(reviewers_id)
+        },
+        "custom_max_papers_invitation": {
+            "value": "{}/-/Custom_Max_Papers".format(reviewers_id)
+        },
+        "match_group": {"value": reviewers_id},
+        "scores_specification": {
+            "value": {
+                venue.get_affinity_score_id(reviewers_id): {
+                    "weight": 1.0,
+                    "default": 0.0,
+                }
+            }
+        },
+        "status": {"value": "Initialized"},
+        "solver": {"value": "FairIR"},
+    }
+
+    config_note = openreview_client.post_note_edit(
+        invitation="{}/-/Assignment_Configuration".format(reviewers_id),
+        signatures=[venue.get_id()],
+        note=Note(content=config),
+    )
+    assert config_note
+
+    missing_header_response = test_client.post(
+        "/match",
+        data=json.dumps({"configNoteId": config_note["note"]["id"]}),
+        content_type="application/json",
+    )
+    assert missing_header_response.status_code == 400
+
+
+def test_routes_missing_config(openreview_context, celery_app, celery_worker):
+    """should return 404 if config note doesn't exist"""
+
+    openreview_client = openreview_context["openreview_client_v2"]
+    test_client = openreview_context["test_client"]
+
+    missing_config_response = test_client.post(
+        "/match",
+        data=json.dumps({"configNoteId": "BAD_CONFIG_NOTE_ID"}),
+        content_type="application/json",
+        headers=openreview_client.headers,
+    )
+    assert missing_config_response.status_code == 404
+
+
+@pytest.mark.skip  # TODO: fix the authorization so that this test passes.
+def test_routes_bad_token(openreview_context, celery_app, celery_worker):
+    """should return 400 if token is bad"""
+    openreview_client = openreview_context["openreview_client"]
+    test_client = openreview_context["test_client"]
+    app = openreview_context["app"]
+
+    bad_token_response = test_client.post(
+        "/match",
+        data=json.dumps({"configNoteId": "BAD_CONFIG_NOTE_ID"}),
+        content_type="application/json",
+        headers={"Authorization": "BAD_TOKEN"},
+    )
+    assert bad_token_response.status_code == 400
+
+
+def test_routes_already_running_or_complete(
+    openreview_context, celery_app, celery_worker
+):
+    """should return 400 if the match is already running or complete"""
+
+    openreview_client = openreview_context["openreview_client_v2"]
+    test_client = openreview_context["test_client"]
+
+    conference_id = "IMCLR.ws/2019/Conference"
+    num_reviewers = 1
+    num_papers = 1
+    reviews_per_paper = 1
+    max_papers = 1
+    min_papers = 0
+    alternates = 0
+
+    venue = clean_start_conference_v2(
+        openreview_client,
+        conference_id,
+        num_reviewers,
+        num_papers,
+        reviews_per_paper,
+    )
+
+    post_fairir_to_api2(openreview_client, conference_id)
+
+    reviewers_id = venue.get_reviewers_id()
+
+    config = {
+        "title": {"value": "integration-test"},
+        "user_demand": {"value": str(reviews_per_paper)},
+        "max_papers": {"value": str(max_papers)},
+        "min_papers": {"value": str(min_papers)},
+        "alternates": {"value": str(alternates)},
+        "config_invitation": {
+            "value": "{}/-/Assignment_Configuration".format(reviewers_id)
+        },
+        "paper_invitation": {"value": venue.get_submission_id()},
+        "assignment_invitation": {
+            "value": venue.get_assignment_id(reviewers_id)
+        },
+        "deployed_assignment_invitation": {
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
+        },
+        "invite_assignment_invitation": {
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
+        },
+        "aggregate_score_invitation": {
+            "value": "{}/-/Aggregate_Score".format(reviewers_id)
+        },
+        "conflicts_invitation": {
+            "value": venue.get_conflict_score_id(reviewers_id)
+        },
+        "custom_max_papers_invitation": {
+            "value": "{}/-/Custom_Max_Papers".format(reviewers_id)
+        },
+        "match_group": {"value": reviewers_id},
+        "scores_specification": {
+            "value": {
+                venue.get_affinity_score_id(reviewers_id): {
+                    "weight": 1.0,
+                    "default": 0.0,
+                }
+            }
+        },
+        "status": {"value": "Running"},
+        "solver": {"value": "FairIR"},
+    }
+
+    config_note = openreview_client.post_note_edit(
+        invitation="{}/-/Assignment_Configuration".format(reviewers_id),
+        signatures=[venue.get_id()],
+        note=Note(content=config),
+    )
+    assert config_note
+
+    already_running_response = test_client.post(
+        "/match",
+        data=json.dumps({"configNoteId": config_note["note"]["id"]}),
+        content_type="application/json",
+        headers=openreview_client.headers,
+    )
+    assert already_running_response.status_code == 400
+
+    config_note = openreview_client.get_note(config_note["note"]["id"])
+    assert config_note.content["status"]["value"] == "Running"
+
+    config_note.content["status"]["value"] = "Complete"
+    config_note = openreview_client.post_note_edit(
+        invitation="{}/-/Assignment_Configuration".format(reviewers_id),
+        signatures=[venue.get_id()],
+        note=Note(id=config_note.id, content=config_note.content),
+    )
+    assert config_note
+    print(
+        "config note set to: ",
+        config_note["note"]["content"]["status"]["value"],
+    )
+
+    already_complete_response = test_client.post(
+        "/match",
+        data=json.dumps({"configNoteId": config_note["note"]["id"]}),
+        content_type="application/json",
+        headers=openreview_client.headers,
+    )
+    assert already_complete_response.status_code == 400
+    config_note = openreview_client.get_note(config_note["note"]["id"])
+    assert config_note.content["status"]["value"] == "Complete"
+
+
+def test_routes_already_queued(openreview_context, celery_app, celery_worker):
+    """should return 400 if the match is already queued"""
+
+    openreview_client = openreview_context["openreview_client_v2"]
+    test_client = openreview_context["test_client"]
+
+    conference_id = "IMCLR.ws/2019/Conference"
+    num_reviewers = 1
+    num_papers = 1
+    reviews_per_paper = 1
+    max_papers = 1
+    min_papers = 0
+    alternates = 0
+
+    venue = clean_start_conference_v2(
+        openreview_client,
+        conference_id,
+        num_reviewers,
+        num_papers,
+        reviews_per_paper,
+    )
+
+    post_fairir_to_api2(openreview_client, conference_id)
+
+    reviewers_id = venue.get_reviewers_id()
+
+    config = {
+        "title": {"value": "integration-test"},
+        "user_demand": {"value": str(reviews_per_paper)},
+        "max_papers": {"value": str(max_papers)},
+        "min_papers": {"value": str(min_papers)},
+        "alternates": {"value": str(alternates)},
+        "config_invitation": {
+            "value": "{}/-/Assignment_Configuration".format(reviewers_id)
+        },
+        "paper_invitation": {"value": venue.get_submission_id()},
+        "assignment_invitation": {
+            "value": venue.get_assignment_id(reviewers_id)
+        },
+        "deployed_assignment_invitation": {
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
+        },
+        "invite_assignment_invitation": {
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
+        },
+        "aggregate_score_invitation": {
+            "value": "{}/-/Aggregate_Score".format(reviewers_id)
+        },
+        "conflicts_invitation": {
+            "value": venue.get_conflict_score_id(reviewers_id)
+        },
+        "custom_max_papers_invitation": {
+            "value": "{}/-/Custom_Max_Papers".format(reviewers_id)
+        },
+        "match_group": {"value": reviewers_id},
+        "scores_specification": {
+            "value": {
+                venue.get_affinity_score_id(reviewers_id): {
+                    "weight": 1.0,
+                    "default": 0.0,
+                }
+            }
+        },
+        "status": {"value": "Queued"},
+        "solver": {"value": "FairIR"},
+    }
+
+    config_note = openreview_client.post_note_edit(
+        invitation="{}/-/Assignment_Configuration".format(reviewers_id),
+        signatures=[venue.get_id()],
+        note=Note(content=config),
+    )
+    assert config_note
+
+    already_queued_response = test_client.post(
+        "/match",
+        data=json.dumps({"configNoteId": config_note["note"]["id"]}),
+        content_type="application/json",
+        headers=openreview_client.headers,
+    )
+    assert already_queued_response.status_code == 400
+
+    config_note = openreview_client.get_note(config_note["note"]["id"])
+    assert config_note.content["status"]["value"] == "Queued"
+
+
+def test_integration_empty_reviewers_list_error(
+    openreview_context, celery_app, celery_worker
+):
+    """
+    Test to check en exception is thrown when the reviewers list is empty.
+    """
+    openreview_client = openreview_context["openreview_client_v2"]
+    test_client = openreview_context["test_client"]
+
+    conference_id = "IMCLR.ws/2021/Conference"
+    num_reviewers = 10
+    num_papers = 10
+    reviews_per_paper = 3
+    max_papers = 5
+    min_papers = 1
+    alternates = 0
+
+    venue = clean_start_conference_v2(
+        openreview_client,
+        conference_id,
+        num_reviewers,
+        num_papers,
+        reviews_per_paper,
+    )
+
+    post_fairir_to_api2(openreview_client, conference_id)
+
+    reviewers_id = venue.get_reviewers_id()
+
+    config = {
+        "title": {"value": "integration-test"},
+        "user_demand": {"value": str(reviews_per_paper)},
+        "max_papers": {"value": str(max_papers)},
+        "min_papers": {"value": str(min_papers)},
+        "alternates": {"value": str(alternates)},
+        "config_invitation": {
+            "value": "{}/-/Assignment_Configuration".format(reviewers_id)
+        },
+        "paper_invitation": {"value": venue.get_submission_id()},
+        "assignment_invitation": {
+            "value": venue.get_assignment_id(reviewers_id)
+        },
+        "deployed_assignment_invitation": {
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
+        },
+        "invite_assignment_invitation": {
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
+        },
+        "aggregate_score_invitation": {
+            "value": "{}/-/Aggregate_Score".format(reviewers_id)
+        },
+        "conflicts_invitation": {
+            "value": venue.get_conflict_score_id(reviewers_id)
+        },
+        "custom_max_papers_invitation": {
+            "value": "{}/-/Custom_Max_Papers".format(reviewers_id)
+        },
+        "match_group": {"value": reviewers_id},
+        "scores_specification": {
+            "value": {
+                venue.get_affinity_score_id(reviewers_id): {
+                    "weight": 1.0,
+                    "default": 0.0,
+                }
+            }
+        },
+        "status": {"value": "Initialized"},
+        "solver": {"value": "FairIR"},
+    }
+
+    config_note = openreview_client.post_note_edit(
+        invitation="{}/-/Assignment_Configuration".format(reviewers_id),
+        signatures=[venue.get_id()],
+        note=Note(content=config),
+    )
+    assert config_note
+
+    # Empty the list of reviewers before calling the matching
+    openreview_client.post_group_edit(
+            invitation = venue.get_meta_invitation_id(),
+            readers = [venue.venue_id],
+            writers = [venue.venue_id],
+            signatures = [venue.venue_id],
+            group = openreview.api.Group(
+                id = reviewers_id,
+                members = []
+            )
+        )
+
+    response = test_client.post(
+        "/match",
+        data=json.dumps({"configNoteId": config_note["note"]["id"]}),
+        content_type="application/json",
+        headers=openreview_client.headers,
+    )
+    assert response.status_code == 200
+
+    matcher_status = wait_for_status(
+        openreview_client, config_note["note"]["id"], api_version=2
+    )
+    assert matcher_status.content["status"]["value"] == "Error"
+    assert (
+        matcher_status.content["error_message"]["value"]
+        == "Reviewers List can not be empty."
+    )
+
+    paper_assignment_edges = openreview_client.get_edges_count(
+        label="integration-test",
+        invitation=venue.get_assignment_id(venue.get_reviewers_id()),
+    )
+
+    assert paper_assignment_edges == 0
+
+
+def test_integration_group_not_found_error(
+    openreview_context, celery_app, celery_worker
+):
+    """
+    Basic integration test. Makes use of the OpenReview Builder
+    """
+    openreview_client = openreview_context["openreview_client_v2"]
+    test_client = openreview_context["test_client"]
+
+    conference_id = "IMCLR.ws/2029/Conference"
+    num_reviewers = 10
+    num_papers = 10
+    reviews_per_paper = 3
+    max_papers = 5
+    min_papers = 1
+    alternates = 0
+
+    venue = clean_start_conference_v2(
+        openreview_client,
+        conference_id,
+        num_reviewers,
+        num_papers,
+        reviews_per_paper,
+    )
+
+    post_fairir_to_api2(openreview_client, conference_id)
+
+    reviewers_id = venue.get_reviewers_id()
+
+    config = {
+        "title": {"value": "integration-test"},
+        "user_demand": {"value": str(reviews_per_paper)},
+        "max_papers": {"value": str(max_papers)},
+        "min_papers": {"value": str(min_papers)},
+        "alternates": {"value": str(alternates)},
+        "config_invitation": {
+            "value": "{}/-/Assignment_Configuration".format(reviewers_id)
+        },
+        "paper_invitation": {"value": venue.get_submission_id()},
+        "assignment_invitation": {
+            "value": venue.get_assignment_id(reviewers_id)
+        },
+        "deployed_assignment_invitation": {
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
+        },
+        "invite_assignment_invitation": {
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
+        },
+        "aggregate_score_invitation": {
+            "value": "{}/-/Aggregate_Score".format(reviewers_id)
+        },
+        "conflicts_invitation": {
+            "value": venue.get_conflict_score_id(reviewers_id)
+        },
+        "custom_max_papers_invitation": {
+            "value": "{}/-/Custom_Max_Papers".format(reviewers_id)
+        },
+        "match_group": {"value": "IMCLR.ws/2029/Conference/NoReviewers"},
+        "scores_specification": {
+            "value": {
+                venue.get_affinity_score_id(reviewers_id): {
+                    "weight": 1.0,
+                    "default": 0.0,
+                }
+            }
+        },
+        "status": {"value": "Initialized"},
+        "solver": {"value": "FairIR"},
+    }
+
+    config_note = openreview_client.post_note_edit(
+        invitation="{}/-/Assignment_Configuration".format(reviewers_id),
+        signatures=[venue.get_id()],
+        note=Note(content=config),
+    )
+    assert config_note
+
+    response = test_client.post(
+        "/match",
+        data=json.dumps({"configNoteId": config_note["note"]["id"]}),
+        content_type="application/json",
+        headers=openreview_client.headers,
+    )
+    assert response.status_code == 404
+
+    matcher_status = wait_for_status(
+        openreview_client, config_note["note"]["id"]
+    )
+    assert (
+        "Group Not Found: IMCLR.ws/2029/Conference/NoReviewers"
+        in matcher_status.content["error_message"]["value"]
+    )
+
+
+def test_integration_group_with_email(
+    openreview_context, celery_app, celery_worker
+):
+    """
+    Basic integration test. Makes use of the OpenReview Builder
+    """
+    openreview_client = openreview_context["openreview_client_v2"]
+    test_client = openreview_context["test_client"]
+
+    conference_id = "IMCLR.ws/2029/Conference"
+    num_reviewers = 10
+    num_papers = 10
+    reviews_per_paper = 3
+    max_papers = 7
+    min_papers = 1
+    alternates = 0
+
+    venue = clean_start_conference_v2(
+        openreview_client,
+        conference_id,
+        num_reviewers,
+        num_papers,
+        reviews_per_paper,
+    )
+
+    post_fairir_to_api2(openreview_client, conference_id)
+
+    openreview_client.add_members_to_group(
+        conference_id + "/Reviewers", "reviewer@mail.com"
+    )
+    reviewers_id = venue.get_reviewers_id()
+
+    config = {
+        "title": {"value": "integration-test-validity"},
+        "user_demand": {"value": str(reviews_per_paper)},
+        "max_papers": {"value": str(max_papers)},
+        "min_papers": {"value": str(min_papers)},
+        "alternates": {"value": str(alternates)},
+        "config_invitation": {
+            "value": "{}/-/Assignment_Configuration".format(reviewers_id)
+        },
+        "paper_invitation": {"value": venue.get_submission_id()},
+        "assignment_invitation": {
+            "value": venue.get_assignment_id(reviewers_id)
+        },
+        "deployed_assignment_invitation": {
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
+        },
+        "invite_assignment_invitation": {
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
+        },
+        "aggregate_score_invitation": {
+            "value": "{}/-/Aggregate_Score".format(reviewers_id)
+        },
+        "conflicts_invitation": {
+            "value": venue.get_conflict_score_id(reviewers_id)
+        },
+        "custom_max_papers_invitation": {
+            "value": "{}/-/Custom_Max_Papers".format(reviewers_id)
+        },
+        "match_group": {"value": reviewers_id},
+        "scores_specification": {
+            "value": {
+                venue.get_affinity_score_id(reviewers_id): {
+                    "weight": 1.0,
+                    "default": 0.0,
+                }
+            }
+        },
+        "status": {"value": "Initialized"},
+        "solver": {"value": "FairFlow"},
+        "allow_zero_score_assignments": {"value": "Yes"},
+    }
+
+    config_note = openreview_client.post_note_edit(
+        invitation="{}/-/Assignment_Configuration".format(reviewers_id),
+        signatures=[venue.get_id()],
+        note=Note(content=config),
+    )
+    assert config_note
+
+    response = test_client.post(
+        "/match",
+        data=json.dumps({"configNoteId": config_note["note"]["id"]}),
+        content_type="application/json",
+        headers=openreview_client.headers,
+    )
+    assert response.status_code == 200
+
+    matcher_status = wait_for_status(
+        openreview_client, config_note["note"]["id"], api_version=2
+    )
+    assert matcher_status.content["status"]["value"] == "Complete"

--- a/tests/test_integration_fairir.py
+++ b/tests/test_integration_fairir.py
@@ -1,0 +1,1276 @@
+"""
+End-to-end integration tests with OpenReview server.
+"""
+
+import json
+
+import openreview
+import pytest
+
+from conftest import clean_start_conference, wait_for_status
+
+
+def test_integration_basic(openreview_context, celery_app, celery_worker):
+    """
+    Basic integration test. Makes use of the OpenReview Builder
+    """
+    openreview_client = openreview_context["openreview_client"]
+    test_client = openreview_context["test_client"]
+
+    conference_id = "ICMLL.ws/2022/Conference"
+    num_reviewers = 10
+    num_papers = 10
+    reviews_per_paper = 3
+    max_papers = 5
+    min_papers = 1
+    alternates = 0
+
+    conference = clean_start_conference(
+        openreview_client,
+        conference_id,
+        num_reviewers,
+        num_papers,
+        reviews_per_paper,
+    )
+
+    reviewers_id = conference.get_reviewers_id()
+
+    config = {
+        "title": "integration-test",
+        "user_demand": str(reviews_per_paper),
+        "max_papers": str(max_papers),
+        "min_papers": str(min_papers),
+        "alternates": str(alternates),
+        "config_invitation": "{}/-/Assignment_Configuration".format(
+            reviewers_id
+        ),
+        "paper_invitation": conference.get_blind_submission_id(),
+        "assignment_invitation": conference.get_paper_assignment_id(
+            reviewers_id
+        ),
+        "deployed_assignment_invitation": conference.get_paper_assignment_id(
+            reviewers_id, deployed=True
+        ),
+        "invite_assignment_invitation": conference.get_paper_assignment_id(
+            reviewers_id, invite=True
+        ),
+        "aggregate_score_invitation": "{}/-/Aggregate_Score".format(
+            reviewers_id
+        ),
+        "conflicts_invitation": conference.get_conflict_score_id(reviewers_id),
+        "custom_max_papers_invitation": "{}/-/Custom_Max_Papers".format(
+            reviewers_id
+        ),
+        "match_group": reviewers_id,
+        "scores_specification": {
+            conference.get_affinity_score_id(reviewers_id): {
+                "weight": 1.0,
+                "default": 0.0,
+            }
+        },
+        "status": "Initialized",
+        "solver": "FairIR",
+    }
+
+    config_note = openreview.Note(
+        **{
+            "invitation": "{}/-/Assignment_Configuration".format(reviewers_id),
+            "readers": [conference.get_id()],
+            "writers": [conference.get_id()],
+            "signatures": [conference.get_id()],
+            "content": config,
+        }
+    )
+
+    config_note = openreview_client.post_note(config_note)
+    assert config_note
+
+    response = test_client.post(
+        "/match",
+        data=json.dumps({"configNoteId": config_note.id}),
+        content_type="application/json",
+        headers=openreview_client.headers,
+    )
+    assert response.status_code == 200
+
+    matcher_status = wait_for_status(openreview_client, config_note.id)
+    assert matcher_status.content["status"] == "Complete"
+
+    paper_assignment_edges = openreview_client.get_edges_count(
+        label="integration-test",
+        invitation=conference.get_paper_assignment_id(
+            conference.get_reviewers_id()
+        ),
+    )
+
+    assert paper_assignment_edges == num_papers * reviews_per_paper
+
+def test_integration_supply_mismatch_error(
+    openreview_context, celery_app, celery_worker
+):
+    """
+    Basic integration test. Makes use of the OpenReview Builder
+    """
+    openreview_client = openreview_context["openreview_client"]
+    test_client = openreview_context["test_client"]
+
+    conference_id = "ABCD.ws/2019/Conference"
+    num_reviewers = 10
+    num_papers = 10
+    reviews_per_paper = 10  # impossible!
+    max_papers = 1
+    min_papers = 1
+    alternates = 0
+
+    conference = clean_start_conference(
+        openreview_client,
+        conference_id,
+        num_reviewers,
+        num_papers,
+        reviews_per_paper,
+    )
+
+    reviewers_id = conference.get_reviewers_id()
+
+    config = {
+        "title": "integration-test-2",
+        "user_demand": str(reviews_per_paper),
+        "max_papers": str(max_papers),
+        "min_papers": str(min_papers),
+        "alternates": str(alternates),
+        "config_invitation": "{}/-/Assignment_Configuration".format(
+            reviewers_id
+        ),
+        "paper_invitation": conference.get_blind_submission_id(),
+        "assignment_invitation": conference.get_paper_assignment_id(
+            reviewers_id
+        ),
+        "deployed_assignment_invitation": conference.get_paper_assignment_id(
+            reviewers_id, deployed=True
+        ),
+        "invite_assignment_invitation": conference.get_paper_assignment_id(
+            reviewers_id, invite=True
+        ),
+        "aggregate_score_invitation": "{}/-/Aggregate_Score".format(
+            reviewers_id
+        ),
+        "conflicts_invitation": conference.get_conflict_score_id(reviewers_id),
+        "custom_max_papers_invitation": "{}/-/Custom_Max_Papers".format(
+            reviewers_id
+        ),
+        "match_group": reviewers_id,
+        "scores_specification": {
+            conference.get_affinity_score_id(reviewers_id): {
+                "weight": 1.0,
+                "default": 0.0,
+            }
+        },
+        "status": "Initialized",
+        "solver": "FairIR",
+    }
+
+    config_note = openreview.Note(
+        **{
+            "invitation": "{}/-/Assignment_Configuration".format(reviewers_id),
+            "readers": [conference.get_id()],
+            "writers": [conference.get_id()],
+            "signatures": [conference.get_id()],
+            "content": config,
+        }
+    )
+
+    config_note = openreview_client.post_note(config_note)
+    assert config_note
+
+    response = test_client.post(
+        "/match",
+        data=json.dumps({"configNoteId": config_note.id}),
+        content_type="application/json",
+        headers=openreview_client.headers,
+    )
+    assert response.status_code == 200
+
+    matcher_status = wait_for_status(openreview_client, config_note.id)
+    assert matcher_status.content["status"] == "No Solution"
+    assert (
+        matcher_status.content["error_message"]
+        == "Total demand (100) is out of range when min review supply is (10) and max review supply is (10)"
+    )
+
+    paper_assignment_edges = openreview_client.get_edges_count(
+        label="integration-test-2",
+        invitation=conference.get_paper_assignment_id(
+            conference.get_reviewers_id()
+        ),
+    )
+
+    assert paper_assignment_edges == 0
+
+
+def test_integration_demand_out_of_supply_range_error(
+    openreview_context, celery_app, celery_worker
+):
+    """
+    Test to check that a No Solution is observed when demand is not in the range of min and max supply
+    """
+    openreview_client = openreview_context["openreview_client"]
+    test_client = openreview_context["test_client"]
+
+    conference_id = "ICMLL.cc/2035/Conference"
+    num_reviewers = 10
+    num_papers = 10
+    reviews_per_paper = 3
+    max_papers = 5
+    min_papers = 4
+    alternates = 0
+
+    conference = clean_start_conference(
+        openreview_client,
+        conference_id,
+        num_reviewers,
+        num_papers,
+        reviews_per_paper,
+    )
+
+    reviewers_id = conference.get_reviewers_id()
+
+    config = {
+        "title": "integration-test",
+        "user_demand": str(reviews_per_paper),
+        "max_papers": str(max_papers),
+        "min_papers": str(min_papers),
+        "alternates": str(alternates),
+        "config_invitation": "{}/-/Assignment_Configuration".format(
+            reviewers_id
+        ),
+        "paper_invitation": conference.get_blind_submission_id(),
+        "assignment_invitation": conference.get_paper_assignment_id(
+            reviewers_id
+        ),
+        "deployed_assignment_invitation": conference.get_paper_assignment_id(
+            reviewers_id, deployed=True
+        ),
+        "invite_assignment_invitation": conference.get_paper_assignment_id(
+            reviewers_id, invite=True
+        ),
+        "aggregate_score_invitation": "{}/-/Aggregate_Score".format(
+            reviewers_id
+        ),
+        "conflicts_invitation": conference.get_conflict_score_id(reviewers_id),
+        "custom_max_papers_invitation": "{}/-/Custom_Max_Papers".format(
+            reviewers_id
+        ),
+        "match_group": reviewers_id,
+        "scores_specification": {
+            conference.get_affinity_score_id(reviewers_id): {
+                "weight": 1.0,
+                "default": 0.0,
+            }
+        },
+        "status": "Initialized",
+        "solver": "FairIR",
+    }
+
+    config_note = openreview.Note(
+        **{
+            "invitation": "{}/-/Assignment_Configuration".format(reviewers_id),
+            "readers": [conference.get_id()],
+            "writers": [conference.get_id()],
+            "signatures": [conference.get_id()],
+            "content": config,
+        }
+    )
+
+    config_note = openreview_client.post_note(config_note)
+    assert config_note
+
+    response = test_client.post(
+        "/match",
+        data=json.dumps({"configNoteId": config_note.id}),
+        content_type="application/json",
+        headers=openreview_client.headers,
+    )
+    assert response.status_code == 200
+
+    matcher_status = wait_for_status(openreview_client, config_note.id)
+    assert matcher_status.content["status"] == "No Solution"
+    assert (
+        matcher_status.content["error_message"]
+        == "Total demand (30) is out of range when min review supply is (40) and max review supply is (50)"
+    )
+
+    paper_assignment_edges = openreview_client.get_edges_count(
+        label="integration-test",
+        invitation=conference.get_paper_assignment_id(
+            conference.get_reviewers_id()
+        ),
+    )
+
+    assert paper_assignment_edges == 0
+
+
+def test_integration_no_scores(openreview_context, celery_app, celery_worker):
+    """
+    Basic integration test. Makes use of the OpenReview Builder
+    """
+    openreview_client = openreview_context["openreview_client"]
+    test_client = openreview_context["test_client"]
+
+    conference_id = "ICMLL.ws/2020/Conference"
+    num_reviewers = 10
+    num_papers = 10
+    reviews_per_paper = 3
+    max_papers = 5
+    min_papers = 1
+    alternates = 0
+
+    conference = clean_start_conference(
+        openreview_client,
+        conference_id,
+        num_reviewers,
+        num_papers,
+        reviews_per_paper,
+    )
+
+    reviewers_id = conference.get_reviewers_id()
+
+    config = {
+        "title": "integration-test",
+        "user_demand": str(reviews_per_paper),
+        "max_papers": str(max_papers),
+        "min_papers": str(min_papers),
+        "alternates": str(alternates),
+        "config_invitation": "{}/-/Assignment_Configuration".format(
+            reviewers_id
+        ),
+        "paper_invitation": conference.get_blind_submission_id(),
+        "assignment_invitation": conference.get_paper_assignment_id(
+            reviewers_id
+        ),
+        "deployed_assignment_invitation": conference.get_paper_assignment_id(
+            reviewers_id, deployed=True
+        ),
+        "invite_assignment_invitation": conference.get_paper_assignment_id(
+            reviewers_id, invite=True
+        ),
+        "aggregate_score_invitation": "{}/-/Aggregate_Score".format(
+            reviewers_id
+        ),
+        "conflicts_invitation": conference.get_conflict_score_id(reviewers_id),
+        "custom_max_papers_invitation": "{}/-/Custom_Max_Papers".format(
+            reviewers_id
+        ),
+        "match_group": reviewers_id,
+        "status": "Initialized",
+        "solver": "FairIR",
+        "allow_zero_score_assignments": "Yes",
+    }
+
+    config_note = openreview.Note(
+        **{
+            "invitation": "{}/-/Assignment_Configuration".format(reviewers_id),
+            "readers": [conference.get_id()],
+            "writers": [conference.get_id()],
+            "signatures": [conference.get_id()],
+            "content": config,
+        }
+    )
+
+    config_note = openreview_client.post_note(config_note)
+    assert config_note
+
+    response = test_client.post(
+        "/match",
+        data=json.dumps({"configNoteId": config_note.id}),
+        content_type="application/json",
+        headers=openreview_client.headers,
+    )
+    assert response.status_code == 200
+
+    matcher_status = wait_for_status(openreview_client, config_note.id)
+
+    config_note = openreview_client.get_note(config_note.id)
+    assert matcher_status.content["status"] == "Complete"
+
+    paper_assignment_edges = openreview_client.get_edges_count(
+        label="integration-test",
+        invitation=conference.get_paper_assignment_id(
+            conference.get_reviewers_id()
+        ),
+    )
+
+    assert paper_assignment_edges == num_papers * reviews_per_paper
+
+
+def test_routes_invalid_invitation(
+    openreview_context, celery_app, celery_worker
+):
+    """"""
+    openreview_client = openreview_context["openreview_client"]
+    test_client = openreview_context["test_client"]
+
+    conference_id = "ICMLL.ws/2019/Conference"
+    num_reviewers = 10
+    num_papers = 10
+    reviews_per_paper = 3
+    max_papers = 5
+    min_papers = 1
+    alternates = 0
+
+    conference = clean_start_conference(
+        openreview_client,
+        conference_id,
+        num_reviewers,
+        num_papers,
+        reviews_per_paper,
+    )
+
+    reviewers_id = conference.get_reviewers_id()
+
+    config = {
+        "title": "integration-test",
+        "user_demand": str(reviews_per_paper),
+        "max_papers": str(max_papers),
+        "min_papers": str(min_papers),
+        "alternates": str(alternates),
+        "config_invitation": "{}/-/Assignment_Configuration".format(
+            reviewers_id
+        ),
+        "paper_invitation": conference.get_blind_submission_id(),
+        "assignment_invitation": conference.get_paper_assignment_id(
+            reviewers_id
+        ),
+        "deployed_assignment_invitation": conference.get_paper_assignment_id(
+            reviewers_id, deployed=True
+        ),
+        "invite_assignment_invitation": conference.get_paper_assignment_id(
+            reviewers_id, invite=True
+        ),
+        "aggregate_score_invitation": "{}/-/Aggregate_Score".format(
+            reviewers_id
+        ),
+        "conflicts_invitation": conference.get_conflict_score_id(reviewers_id),
+        "custom_max_papers_invitation": "{}/-/Custom_Max_Papers".format(
+            reviewers_id
+        ),
+        "match_group": reviewers_id,
+        "scores_specification": {
+            # conference.get_affinity_score_id(reviewers_id): {
+            #     'weight': 1.0,
+            #     'default': 0.0
+            # },
+            "<some_invalid_invitation>": {"weight": 1.0, "default": 0.0}
+        },
+        "status": "Initialized",
+        "solver": "FairIR",
+    }
+
+    config_note = openreview.Note(
+        **{
+            "invitation": "{}/-/Assignment_Configuration".format(reviewers_id),
+            "readers": [conference.get_id()],
+            "writers": [conference.get_id()],
+            "signatures": [conference.get_id()],
+            "content": config,
+        }
+    )
+
+    config_note = openreview_client.post_note(config_note)
+    assert config_note
+
+    invalid_invitation_response = test_client.post(
+        "/match",
+        data=json.dumps({"configNoteId": config_note.id}),
+        content_type="application/json",
+        headers=openreview_client.headers,
+    )
+    assert invalid_invitation_response.status_code == 404
+
+    config_note = openreview_client.get_note(config_note.id)
+    assert config_note.content["status"] == "Error"
+
+
+def test_routes_missing_header(openreview_context, celery_app, celery_worker):
+    """request with missing header should response with 400"""
+    openreview_client = openreview_context["openreview_client"]
+    test_client = openreview_context["test_client"]
+
+    conference_id = "ICMLL.ws/2019/Conference"
+    num_reviewers = 10
+    num_papers = 10
+    reviews_per_paper = 3
+    max_papers = 5
+    min_papers = 1
+    alternates = 0
+
+    conference = clean_start_conference(
+        openreview_client,
+        conference_id,
+        num_reviewers,
+        num_papers,
+        reviews_per_paper,
+    )
+
+    reviewers_id = conference.get_reviewers_id()
+
+    config = {
+        "title": "integration-test",
+        "user_demand": str(reviews_per_paper),
+        "max_papers": str(max_papers),
+        "min_papers": str(min_papers),
+        "alternates": str(alternates),
+        "config_invitation": "{}/-/Assignment_Configuration".format(
+            reviewers_id
+        ),
+        "paper_invitation": conference.get_blind_submission_id(),
+        "assignment_invitation": conference.get_paper_assignment_id(
+            reviewers_id
+        ),
+        "deployed_assignment_invitation": conference.get_paper_assignment_id(
+            reviewers_id, deployed=True
+        ),
+        "invite_assignment_invitation": conference.get_paper_assignment_id(
+            reviewers_id, invite=True
+        ),
+        "aggregate_score_invitation": "{}/-/Aggregate_Score".format(
+            reviewers_id
+        ),
+        "conflicts_invitation": conference.get_conflict_score_id(reviewers_id),
+        "custom_max_papers_invitation": "{}/-/Custom_Max_Papers".format(
+            reviewers_id
+        ),
+        "match_group": reviewers_id,
+        "scores_specification": {
+            conference.get_affinity_score_id(reviewers_id): {
+                "weight": 1.0,
+                "default": 0.0,
+            }
+        },
+        "status": "Initialized",
+        "solver": "FairIR",
+    }
+
+    config_note = openreview.Note(
+        **{
+            "invitation": "{}/-/Assignment_Configuration".format(reviewers_id),
+            "readers": [conference.get_id()],
+            "writers": [conference.get_id()],
+            "signatures": [conference.get_id()],
+            "content": config,
+        }
+    )
+
+    config_note = openreview_client.post_note(config_note)
+    assert config_note
+
+    missing_header_response = test_client.post(
+        "/match",
+        data=json.dumps({"configNoteId": config_note.id}),
+        content_type="application/json",
+    )
+    assert missing_header_response.status_code == 400
+
+
+def test_routes_missing_config(openreview_context, celery_app, celery_worker):
+    """should return 404 if config note doesn't exist"""
+
+    openreview_client = openreview_context["openreview_client"]
+    test_client = openreview_context["test_client"]
+
+    missing_config_response = test_client.post(
+        "/match",
+        data=json.dumps({"configNoteId": "BAD_CONFIG_NOTE_ID"}),
+        content_type="application/json",
+        headers=openreview_client.headers,
+    )
+    assert missing_config_response.status_code == 404
+
+
+@pytest.mark.skip  # TODO: fix the authorization so that this test passes.
+def test_routes_bad_token(openreview_context, celery_app, celery_worker):
+    """should return 400 if token is bad"""
+    openreview_client = openreview_context["openreview_client"]
+    test_client = openreview_context["test_client"]
+    app = openreview_context["app"]
+
+    bad_token_response = test_client.post(
+        "/match",
+        data=json.dumps({"configNoteId": "BAD_CONFIG_NOTE_ID"}),
+        content_type="application/json",
+        headers={"Authorization": "BAD_TOKEN"},
+    )
+    assert bad_token_response.status_code == 400
+
+
+@pytest.mark.skip  # TODO: fix authorization so that this test passes.
+def test_routes_forbidden_config(
+    openreview_context, celery_app, celery_worker
+):
+    """should return 403 if user does not have permission on config note"""
+
+    openreview_client = openreview_context["openreview_client"]
+    test_client = openreview_context["test_client"]
+    app = openreview_context["app"]
+
+    conference_id = "AKBC.ws/2019/Conference"
+    num_reviewers = 1
+    num_papers = 1
+    reviews_per_paper = 1
+    max_papers = 1
+    min_papers = 0
+    alternates = 0
+
+    conference = clean_start_conference(
+        openreview_client,
+        conference_id,
+        num_reviewers,
+        num_papers,
+        reviews_per_paper,
+    )
+
+    reviewers_id = conference.get_reviewers_id()
+
+    config = {
+        "title": "integration-test",
+        "user_demand": str(reviews_per_paper),
+        "max_papers": str(max_papers),
+        "min_papers": str(min_papers),
+        "alternates": str(alternates),
+        "config_invitation": "{}/-/Assignment_Configuration".format(
+            reviewers_id
+        ),
+        "paper_invitation": conference.get_blind_submission_id(),
+        "assignment_invitation": conference.get_paper_assignment_id(
+            reviewers_id
+        ),
+        "deployed_assignment_invitation": conference.get_paper_assignment_id(
+            reviewers_id, deployed=True
+        ),
+        "invite_assignment_invitation": conference.get_paper_assignment_id(
+            reviewers_id, invite=True
+        ),
+        "aggregate_score_invitation": "{}/-/Aggregate_Score".format(
+            reviewers_id
+        ),
+        "conflicts_invitation": conference.get_conflict_score_id(reviewers_id),
+        "custom_max_papers_invitation": "{}/-/Custom_Max_Papers".format(
+            reviewers_id
+        ),
+        "match_group": reviewers_id,
+        "scores_specification": {
+            conference.get_affinity_score_id(reviewers_id): {
+                "weight": 1.0,
+                "default": 0.0,
+            }
+        },
+        "status": "Initialized",
+        "solver": "FairIR",
+    }
+
+    config_note = openreview.Note(
+        **{
+            "invitation": "{}/-/Assignment_Configuration".format(reviewers_id),
+            "readers": [conference.get_id()],
+            "writers": [conference.get_id()],
+            "signatures": [conference.get_id()],
+            "content": config,
+        }
+    )
+
+    config_note = openreview_client.post_note(config_note)
+    assert config_note
+
+    guest_client = openreview.Client(
+        username="", password="", baseurl=app.config["OPENREVIEW_BASEURL"]
+    )
+
+    forbidden_response = test_client.post(
+        "/match",
+        data=json.dumps({"configNoteId": config_note.id}),
+        content_type="application/json",
+        headers=guest_client.headers,
+    )
+    assert forbidden_response.status_code == 403
+
+
+def test_routes_already_running_or_complete(
+    openreview_context, celery_app, celery_worker
+):
+    """should return 400 if the match is already running or complete"""
+
+    openreview_client = openreview_context["openreview_client"]
+    test_client = openreview_context["test_client"]
+
+    conference_id = "ICMLL.ws/2019/Conference"
+    num_reviewers = 1
+    num_papers = 1
+    reviews_per_paper = 1
+    max_papers = 1
+    min_papers = 0
+    alternates = 0
+
+    conference = clean_start_conference(
+        openreview_client,
+        conference_id,
+        num_reviewers,
+        num_papers,
+        reviews_per_paper,
+    )
+
+    reviewers_id = conference.get_reviewers_id()
+
+    config = {
+        "title": "integration-test",
+        "user_demand": str(reviews_per_paper),
+        "max_papers": str(max_papers),
+        "min_papers": str(min_papers),
+        "alternates": str(alternates),
+        "config_invitation": "{}/-/Assignment_Configuration".format(
+            reviewers_id
+        ),
+        "paper_invitation": conference.get_blind_submission_id(),
+        "assignment_invitation": conference.get_paper_assignment_id(
+            reviewers_id
+        ),
+        "deployed_assignment_invitation": conference.get_paper_assignment_id(
+            reviewers_id, deployed=True
+        ),
+        "invite_assignment_invitation": conference.get_paper_assignment_id(
+            reviewers_id, invite=True
+        ),
+        "aggregate_score_invitation": "{}/-/Aggregate_Score".format(
+            reviewers_id
+        ),
+        "conflicts_invitation": conference.get_conflict_score_id(reviewers_id),
+        "custom_max_papers_invitation": "{}/-/Custom_Max_Papers".format(
+            reviewers_id
+        ),
+        "match_group": reviewers_id,
+        "scores_specification": {
+            conference.get_affinity_score_id(reviewers_id): {
+                "weight": 1.0,
+                "default": 0.0,
+            }
+        },
+        "status": "Running",
+        "solver": "FairIR",
+    }
+
+    config_note = openreview.Note(
+        **{
+            "invitation": "{}/-/Assignment_Configuration".format(reviewers_id),
+            "readers": [conference.get_id()],
+            "writers": [conference.get_id()],
+            "signatures": [conference.get_id()],
+            "content": config,
+        }
+    )
+
+    config_note = openreview_client.post_note(config_note)
+    assert config_note
+
+    already_running_response = test_client.post(
+        "/match",
+        data=json.dumps({"configNoteId": config_note.id}),
+        content_type="application/json",
+        headers=openreview_client.headers,
+    )
+    assert already_running_response.status_code == 400
+
+    config_note = openreview_client.get_note(config_note.id)
+    assert config_note.content["status"] == "Running"
+
+    config_note.content["status"] = "Complete"
+    config_note = openreview_client.post_note(config_note)
+    assert config_note
+    print("config note set to: ", config_note.content["status"])
+
+    already_complete_response = test_client.post(
+        "/match",
+        data=json.dumps({"configNoteId": config_note.id}),
+        content_type="application/json",
+        headers=openreview_client.headers,
+    )
+    assert already_complete_response.status_code == 400
+    config_note = openreview_client.get_note(config_note.id)
+    assert config_note.content["status"] == "Complete"
+
+
+def test_routes_already_queued(openreview_context, celery_app, celery_worker):
+    """should return 400 if the match is already queued"""
+
+    openreview_client = openreview_context["openreview_client"]
+    test_client = openreview_context["test_client"]
+
+    conference_id = "ICMLL.ws/2019/Conference"
+    num_reviewers = 1
+    num_papers = 1
+    reviews_per_paper = 1
+    max_papers = 1
+    min_papers = 0
+    alternates = 0
+
+    conference = clean_start_conference(
+        openreview_client,
+        conference_id,
+        num_reviewers,
+        num_papers,
+        reviews_per_paper,
+    )
+
+    reviewers_id = conference.get_reviewers_id()
+
+    config = {
+        "title": "integration-test",
+        "user_demand": str(reviews_per_paper),
+        "max_papers": str(max_papers),
+        "min_papers": str(min_papers),
+        "alternates": str(alternates),
+        "config_invitation": "{}/-/Assignment_Configuration".format(
+            reviewers_id
+        ),
+        "paper_invitation": conference.get_blind_submission_id(),
+        "assignment_invitation": conference.get_paper_assignment_id(
+            reviewers_id
+        ),
+        "deployed_assignment_invitation": conference.get_paper_assignment_id(
+            reviewers_id, deployed=True
+        ),
+        "invite_assignment_invitation": conference.get_paper_assignment_id(
+            reviewers_id, invite=True
+        ),
+        "aggregate_score_invitation": "{}/-/Aggregate_Score".format(
+            reviewers_id
+        ),
+        "conflicts_invitation": conference.get_conflict_score_id(reviewers_id),
+        "custom_max_papers_invitation": "{}/-/Custom_Max_Papers".format(
+            reviewers_id
+        ),
+        "match_group": reviewers_id,
+        "scores_specification": {
+            conference.get_affinity_score_id(reviewers_id): {
+                "weight": 1.0,
+                "default": 0.0,
+            }
+        },
+        "status": "Queued",
+        "solver": "FairIR",
+    }
+
+    config_note = openreview.Note(
+        **{
+            "invitation": "{}/-/Assignment_Configuration".format(reviewers_id),
+            "readers": [conference.get_id()],
+            "writers": [conference.get_id()],
+            "signatures": [conference.get_id()],
+            "content": config,
+        }
+    )
+
+    config_note = openreview_client.post_note(config_note)
+    assert config_note
+
+    already_queued_response = test_client.post(
+        "/match",
+        data=json.dumps({"configNoteId": config_note.id}),
+        content_type="application/json",
+        headers=openreview_client.headers,
+    )
+    assert already_queued_response.status_code == 400
+
+    config_note = openreview_client.get_note(config_note.id)
+    assert config_note.content["status"] == "Queued"
+
+
+def test_integration_empty_reviewers_list_error(
+    openreview_context, celery_app, celery_worker
+):
+    """
+    Test to check en exception is thrown when the reviewers list is empty.
+    """
+    openreview_client = openreview_context["openreview_client"]
+    test_client = openreview_context["test_client"]
+
+    conference_id = "ICMLL.ws/2021/Conference"
+    num_reviewers = 10
+    num_papers = 10
+    reviews_per_paper = 3
+    max_papers = 5
+    min_papers = 1
+    alternates = 0
+
+    conference = clean_start_conference(
+        openreview_client,
+        conference_id,
+        num_reviewers,
+        num_papers,
+        reviews_per_paper,
+    )
+
+    reviewers_id = conference.get_reviewers_id()
+
+    config = {
+        "title": "integration-test",
+        "user_demand": str(reviews_per_paper),
+        "max_papers": str(max_papers),
+        "min_papers": str(min_papers),
+        "alternates": str(alternates),
+        "config_invitation": "{}/-/Assignment_Configuration".format(
+            reviewers_id
+        ),
+        "paper_invitation": conference.get_blind_submission_id(),
+        "assignment_invitation": conference.get_paper_assignment_id(
+            reviewers_id
+        ),
+        "deployed_assignment_invitation": conference.get_paper_assignment_id(
+            reviewers_id, deployed=True
+        ),
+        "invite_assignment_invitation": conference.get_paper_assignment_id(
+            reviewers_id, invite=True
+        ),
+        "aggregate_score_invitation": "{}/-/Aggregate_Score".format(
+            reviewers_id
+        ),
+        "conflicts_invitation": conference.get_conflict_score_id(reviewers_id),
+        "custom_max_papers_invitation": "{}/-/Custom_Max_Papers".format(
+            reviewers_id
+        ),
+        "match_group": reviewers_id,
+        "scores_specification": {
+            conference.get_affinity_score_id(reviewers_id): {
+                "weight": 1.0,
+                "default": 0.0,
+            }
+        },
+        "status": "Initialized",
+        "solver": "FairIR",
+    }
+
+    config_note = openreview.Note(
+        **{
+            "invitation": "{}/-/Assignment_Configuration".format(reviewers_id),
+            "readers": [conference.get_id()],
+            "writers": [conference.get_id()],
+            "signatures": [conference.get_id()],
+            "content": config,
+        }
+    )
+
+    config_note = openreview_client.post_note(config_note)
+    assert config_note
+
+    # Empty the list of reviewers before calling the matching
+    reviewers_group = openreview_client.get_group(reviewers_id)
+    reviewers_group.members = []
+    openreview_client.post_group(reviewers_group)
+
+    response = test_client.post(
+        "/match",
+        data=json.dumps({"configNoteId": config_note.id}),
+        content_type="application/json",
+        headers=openreview_client.headers,
+    )
+    assert response.status_code == 200
+
+    matcher_status = wait_for_status(openreview_client, config_note.id)
+    assert matcher_status.content["status"] == "Error"
+    assert (
+        matcher_status.content["error_message"]
+        == "Reviewers List can not be empty."
+    )
+
+    paper_assignment_edges = openreview_client.get_edges_count(
+        label="integration-test",
+        invitation=conference.get_paper_assignment_id(
+            conference.get_reviewers_id()
+        ),
+    )
+
+    assert paper_assignment_edges == 0
+
+
+@pytest.mark.skip  # TODO: how to set number of papers passed as zero
+def test_integration_empty_papers_list_error(openreview_context):
+    """
+    Test to check en exception is thrown when the reviewers list is empty.
+    """
+    openreview_client = openreview_context["openreview_client"]
+    test_client = openreview_context["test_client"]
+
+    conference_id = "AKBC.ws/2022/Conference"
+    num_reviewers = 15
+    num_papers = 0
+    reviews_per_paper = 3
+    max_papers = 5
+    min_papers = 1
+    alternates = 0
+
+    conference = clean_start_conference(
+        openreview_client,
+        conference_id,
+        num_reviewers,
+        num_papers,
+        reviews_per_paper,
+    )
+
+    reviewers_id = conference.get_reviewers_id()
+
+    config = {
+        "title": "integration-test",
+        "user_demand": str(reviews_per_paper),
+        "max_papers": str(max_papers),
+        "min_papers": str(min_papers),
+        "alternates": str(alternates),
+        "config_invitation": "{}/-/Assignment_Configuration".format(
+            reviewers_id
+        ),
+        "paper_invitation": conference.get_blind_submission_id(),
+        "assignment_invitation": conference.get_paper_assignment_id(
+            reviewers_id
+        ),
+        "deployed_assignment_invitation": conference.get_paper_assignment_id(
+            reviewers_id, deployed=True
+        ),
+        "invite_assignment_invitation": conference.get_paper_assignment_id(
+            reviewers_id, invite=True
+        ),
+        "aggregate_score_invitation": "{}/-/Aggregate_Score".format(
+            reviewers_id
+        ),
+        "conflicts_invitation": conference.get_conflict_score_id(reviewers_id),
+        "custom_max_papers_invitation": "{}/-/Custom_Max_Papers".format(
+            reviewers_id
+        ),
+        "match_group": reviewers_id,
+        "scores_specification": {
+            conference.get_affinity_score_id(reviewers_id): {
+                "weight": 1.0,
+                "default": 0.0,
+            }
+        },
+        "status": "Initialized",
+        "solver": "FairIR",
+    }
+
+    config_note = openreview.Note(
+        **{
+            "invitation": "{}/-/Assignment_Configuration".format(reviewers_id),
+            "readers": [conference.get_id()],
+            "writers": [conference.get_id()],
+            "signatures": [conference.get_id()],
+            "content": config,
+        }
+    )
+
+    config_note = openreview_client.post_note(config_note)
+    assert config_note
+
+    response = test_client.post(
+        "/match",
+        data=json.dumps({"configNoteId": config_note.id}),
+        content_type="application/json",
+        headers=openreview_client.headers,
+    )
+    assert response.status_code == 200
+
+    matcher_status = wait_for_status(openreview_client, config_note.id)
+    assert matcher_status.content["status"] == "Error"
+    assert (
+        matcher_status.content["error_message"]
+        == "Papers List can not be empty."
+    )
+
+    paper_assignment_edges = openreview_client.get_edges_count(
+        label="integration-test",
+        invitation=conference.get_paper_assignment_id(
+            conference.get_reviewers_id()
+        ),
+    )
+
+    assert paper_assignment_edges == 0
+
+
+def test_integration_group_not_found_error(
+    openreview_context, celery_app, celery_worker
+):
+    """
+    Basic integration test. Makes use of the OpenReview Builder
+    """
+    openreview_client = openreview_context["openreview_client"]
+    test_client = openreview_context["test_client"]
+
+    conference_id = "ICMLL.ws/2029/Conference"
+    num_reviewers = 10
+    num_papers = 10
+    reviews_per_paper = 3
+    max_papers = 5
+    min_papers = 1
+    alternates = 0
+
+    conference = clean_start_conference(
+        openreview_client,
+        conference_id,
+        num_reviewers,
+        num_papers,
+        reviews_per_paper,
+    )
+
+    reviewers_id = conference.get_reviewers_id()
+
+    config = {
+        "title": "integration-test",
+        "user_demand": str(reviews_per_paper),
+        "max_papers": str(max_papers),
+        "min_papers": str(min_papers),
+        "alternates": str(alternates),
+        "config_invitation": "{}/-/Assignment_Configuration".format(
+            reviewers_id
+        ),
+        "paper_invitation": conference.get_blind_submission_id(),
+        "assignment_invitation": conference.get_paper_assignment_id(
+            reviewers_id
+        ),
+        "deployed_assignment_invitation": conference.get_paper_assignment_id(
+            reviewers_id, deployed=True
+        ),
+        "invite_assignment_invitation": conference.get_paper_assignment_id(
+            reviewers_id, invite=True
+        ),
+        "aggregate_score_invitation": "{}/-/Aggregate_Score".format(
+            reviewers_id
+        ),
+        "conflicts_invitation": conference.get_conflict_score_id(reviewers_id),
+        "custom_max_papers_invitation": "{}/-/Custom_Max_Papers".format(
+            reviewers_id
+        ),
+        "match_group": "ICMLL.ws/2029/Conference/NoReviewers",
+        "scores_specification": {
+            conference.get_affinity_score_id(reviewers_id): {
+                "weight": 1.0,
+                "default": 0.0,
+            }
+        },
+        "status": "Initialized",
+        "solver": "FairIR",
+    }
+
+    config_note = openreview.Note(
+        **{
+            "invitation": "{}/-/Assignment_Configuration".format(reviewers_id),
+            "readers": [conference.get_id()],
+            "writers": [conference.get_id()],
+            "signatures": [conference.get_id()],
+            "content": config,
+        }
+    )
+
+    config_note = openreview_client.post_note(config_note)
+    assert config_note
+
+    response = test_client.post(
+        "/match",
+        data=json.dumps({"configNoteId": config_note.id}),
+        content_type="application/json",
+        headers=openreview_client.headers,
+    )
+    assert response.status_code == 404
+
+    matcher_status = wait_for_status(openreview_client, config_note.id)
+    assert matcher_status.content["status"] == "Error"
+    assert (
+        "Group Not Found: ICMLL.ws/2029/Conference/NoReviewers"
+        in matcher_status.content["error_message"]
+    )
+
+
+def test_integration_group_with_email(
+    openreview_context, celery_app, celery_worker
+):
+    """
+    Basic integration test. Makes use of the OpenReview Builder
+    """
+    openreview_client = openreview_context["openreview_client"]
+    test_client = openreview_context["test_client"]
+
+    conference_id = "ICMLL.ws/2029/Conference"
+    num_reviewers = 10
+    num_papers = 10
+    reviews_per_paper = 3
+    max_papers = 7
+    min_papers = 1
+    alternates = 0
+
+    conference = clean_start_conference(
+        openreview_client,
+        conference_id,
+        num_reviewers,
+        num_papers,
+        reviews_per_paper,
+    )
+
+    openreview_client.add_members_to_group(
+        conference_id + "/Reviewers", "reviewer@mail.com"
+    )
+    reviewers_id = conference.get_reviewers_id()
+
+    config = {
+        "title": "integration-test",
+        "user_demand": str(reviews_per_paper),
+        "max_papers": str(max_papers),
+        "min_papers": str(min_papers),
+        "alternates": str(alternates),
+        "config_invitation": "{}/-/Assignment_Configuration".format(
+            reviewers_id
+        ),
+        "paper_invitation": conference.get_blind_submission_id(),
+        "assignment_invitation": conference.get_paper_assignment_id(
+            reviewers_id
+        ),
+        "deployed_assignment_invitation": conference.get_paper_assignment_id(
+            reviewers_id, deployed=True
+        ),
+        "invite_assignment_invitation": conference.get_paper_assignment_id(
+            reviewers_id, invite=True
+        ),
+        "aggregate_score_invitation": "{}/-/Aggregate_Score".format(
+            reviewers_id
+        ),
+        "conflicts_invitation": conference.get_conflict_score_id(reviewers_id),
+        "custom_max_papers_invitation": "{}/-/Custom_Max_Papers".format(
+            reviewers_id
+        ),
+        "match_group": "ICMLL.ws/2029/Conference/Reviewers",
+        "scores_specification": {
+            conference.get_affinity_score_id(reviewers_id): {
+                "weight": 1.0,
+                "default": 0.0,
+            }
+        },
+        "status": "Initialized",
+        "solver": "FairIR",
+        "allow_zero_score_assignments": "Yes",
+    }
+
+    config_note = openreview.Note(
+        **{
+            "invitation": "{}/-/Assignment_Configuration".format(reviewers_id),
+            "readers": [conference.get_id()],
+            "writers": [conference.get_id()],
+            "signatures": [conference.get_id()],
+            "content": config,
+        }
+    )
+
+    config_note = openreview_client.post_note(config_note)
+    assert config_note
+
+    response = test_client.post(
+        "/match",
+        data=json.dumps({"configNoteId": config_note.id}),
+        content_type="application/json",
+        headers=openreview_client.headers,
+    )
+    assert response.status_code == 200
+
+    matcher_status = wait_for_status(openreview_client, config_note.id)
+    assert matcher_status.content["status"] == "Complete"

--- a/tests/test_integration_fairir.py
+++ b/tests/test_integration_fairir.py
@@ -7,7 +7,7 @@ import json
 import openreview
 import pytest
 
-from conftest import clean_start_conference, wait_for_status
+from conftest import clean_start_conference, wait_for_status, post_fairir_to_api1
 
 
 def test_integration_basic(openreview_context, celery_app, celery_worker):
@@ -32,6 +32,8 @@ def test_integration_basic(openreview_context, celery_app, celery_worker):
         num_papers,
         reviews_per_paper,
     )
+
+    post_fairir_to_api1(openreview_client, conference_id)
 
     reviewers_id = conference.get_reviewers_id()
 
@@ -129,6 +131,8 @@ def test_integration_supply_mismatch_error(
         num_papers,
         reviews_per_paper,
     )
+
+    post_fairir_to_api1(openreview_client, conference_id)
 
     reviewers_id = conference.get_reviewers_id()
 
@@ -232,6 +236,8 @@ def test_integration_demand_out_of_supply_range_error(
         reviews_per_paper,
     )
 
+    post_fairir_to_api1(openreview_client, conference_id)
+
     reviewers_id = conference.get_reviewers_id()
 
     config = {
@@ -332,6 +338,8 @@ def test_integration_no_scores(openreview_context, celery_app, celery_worker):
         reviews_per_paper,
     )
 
+    post_fairir_to_api1(openreview_client, conference_id)
+
     reviewers_id = conference.get_reviewers_id()
 
     config = {
@@ -425,6 +433,8 @@ def test_routes_invalid_invitation(
         reviews_per_paper,
     )
 
+    post_fairir_to_api1(openreview_client, conference_id)
+
     reviewers_id = conference.get_reviewers_id()
 
     config = {
@@ -510,6 +520,8 @@ def test_routes_missing_header(openreview_context, celery_app, celery_worker):
         num_papers,
         reviews_per_paper,
     )
+
+    post_fairir_to_api1(openreview_client, conference_id)
 
     reviewers_id = conference.get_reviewers_id()
 
@@ -717,6 +729,8 @@ def test_routes_already_running_or_complete(
         reviews_per_paper,
     )
 
+    post_fairir_to_api1(openreview_client, conference_id)
+
     reviewers_id = conference.get_reviewers_id()
 
     config = {
@@ -818,6 +832,8 @@ def test_routes_already_queued(openreview_context, celery_app, celery_worker):
         reviews_per_paper,
     )
 
+    post_fairir_to_api1(openreview_client, conference_id)
+
     reviewers_id = conference.get_reviewers_id()
 
     config = {
@@ -906,6 +922,8 @@ def test_integration_empty_reviewers_list_error(
         num_papers,
         reviews_per_paper,
     )
+
+    post_fairir_to_api1(openreview_client, conference_id)
 
     reviewers_id = conference.get_reviewers_id()
 
@@ -1115,6 +1133,8 @@ def test_integration_group_not_found_error(
         reviews_per_paper,
     )
 
+    post_fairir_to_api1(openreview_client, conference_id)
+
     reviewers_id = conference.get_reviewers_id()
 
     config = {
@@ -1207,6 +1227,8 @@ def test_integration_group_with_email(
         num_papers,
         reviews_per_paper,
     )
+
+    post_fairir_to_api1(openreview_client, conference_id)
 
     openreview_client.add_members_to_group(
         conference_id + "/Reviewers", "reviewer@mail.com"

--- a/tests/test_solvers_fairir.py
+++ b/tests/test_solvers_fairir.py
@@ -1,0 +1,277 @@
+from collections import namedtuple
+import pytest
+from matcher.core import SolverException
+import numpy as np
+from matcher.solvers import FairIR
+from conftest import assert_arrays
+
+encoder = namedtuple('Encoder', ['aggregate_score_matrix', 'constraint_matrix'])
+
+def check_solution(solver, expected_cost):
+    assert solver.optimal_cost == solver.cost, "Minimum cost solution is not the sum of the flows * unit cost in result matrix"
+    assert solver.cost == expected_cost,  "Lowest cost solution should have cost = {}".format(expected_cost)
+
+def test_solvers_pr4a_random():
+    '''When costs are all zero, compute random assignments'''
+    aggregate_score_matrix_A = np.transpose(np.array([
+        [0, 0, 0],
+        [0, 0, 0],
+        [0, 0, 0],
+        [0, 0, 0]
+    ]))
+    constraint_matrix = np.zeros(np.shape(aggregate_score_matrix_A))
+    solver_A = FairIR(
+        [1,1,1,1],
+        [2,2,2,2],
+        [2,2,2],
+        encoder(aggregate_score_matrix_A, constraint_matrix)
+    )
+    res_A = solver_A.solve()
+    print(res_A)
+    assert res_A.shape == (3,4)
+
+def test_solvers_pr4a_simple_attribute_constraint():
+    '''Test constraint that each paper must have reviewer[3] as a reviewer'''
+    aggregate_score_matrix_A = np.transpose(np.array([
+        [0, 0, 0],
+        [0, 0, 0],
+        [0, 0, 0],
+        [0, 0, 0]
+    ]))
+    constraint_matrix = np.zeros(np.shape(aggregate_score_matrix_A))
+    solver_A = FairIR(
+        [0,0,0,0],
+        [2,2,2,3],
+        [2,2,2],
+        encoder(aggregate_score_matrix_A, constraint_matrix),
+        attr_constraints=[{
+            'name': 'Seniority',
+            'comparator': '<=',
+            'bound': 1,
+            'members': [3]
+        }]
+    )
+    res_A = solver_A.solve()
+    print(res_A)
+    for paper_idx in range(3):
+        assert res_A[paper_idx][3] == 1
+    assert res_A.shape == (3,4)
+
+def test_solvers_pr4a_structure_attribute_constraint():
+    '''Test constraint that each paper must have reviewer[3] as a reviewer as well as obey similarity structure'''
+    aggregate_score_matrix_A = np.transpose(np.array([
+        [0.5, 0, 0],
+        [0, 0.5, 0],
+        [0, 0, 0.5],
+        [0, 0, 0]
+    ]))
+    constraint_matrix = np.zeros(np.shape(aggregate_score_matrix_A))
+    solver_A = FairIR(
+        [0,0,0,0],
+        [2,2,2,3],
+        [2,2,2],
+        encoder(aggregate_score_matrix_A, constraint_matrix),
+        attr_constraints=[{
+            'name': 'Seniority',
+            'comparator': '<=',
+            'bound': 1,
+            'members': [3]
+        }]
+    )
+    res_A = solver_A.solve()
+    print(res_A)
+    for paper_idx in range(3):
+        assert res_A[paper_idx][3] == 1
+
+    assert res_A[0][0] == 1
+    assert res_A[1][1] == 1
+    assert res_A[2][2] == 1
+    assert res_A.shape == (3,4)
+
+def test_solvers_pr4a_attribute_constraint_over_similarity():
+    '''Test multiple constraint sets that go against highest similarity'''
+    aggregate_score_matrix_A = np.transpose(np.array([
+        [0.5, 0, 0],
+        [0.5, 0, 0],
+        [0, 0, 0.5],
+        [0, 0, 0.5]
+    ]))
+    constraint_matrix = np.zeros(np.shape(aggregate_score_matrix_A))
+    solver_A = FairIR(
+        [0,0,0,0],
+        [2,2,2,3],
+        [2,2,2],
+        encoder(aggregate_score_matrix_A, constraint_matrix),
+        attr_constraints=[{
+            'name': 'constr1',
+            'comparator': '<=',
+            'bound': 1,
+            'members': [0, 1]
+        },
+        {
+            'name': 'constr2',
+            'comparator': '<=',
+            'bound': 1,
+            'members': [2, 3]
+        }]
+    )
+    res_A = solver_A.solve()
+    print(res_A)
+    assert res_A.shape == (3,4)
+    assert bool(res_A[0][0] == 1) ^ bool(res_A[0][1] == 1)
+    assert bool(res_A[2][2] == 1) ^ bool(res_A[2][3] == 1)
+
+def test_solvers_pr4a_conflict():
+    '''When reviewer[1] has conflicts with all papers, assert that no assignments were made to them'''
+    conflicted_reviewer_idx = 1
+
+    aggregate_score_matrix_A = np.transpose(np.array([
+        [0, 0, 0],
+        [0, 0, 0],
+        [0, 0, 0],
+        [0, 0, 0]
+    ]))
+    constraint_matrix = np.transpose(np.array([
+        [0, 0, 0],
+        [-1, -1, -1],
+        [0, 0, 0],
+        [0, 0, 0]
+    ]))
+    solver_A = FairIR(
+        [1,1,1,1],
+        [2,2,2,2],
+        [2,2,2],
+        encoder(aggregate_score_matrix_A, constraint_matrix)
+    )
+    res_A = solver_A.solve()
+    print(res_A)
+    assert res_A.shape == (3,4)
+    for paper_idx in range(3):
+        assert res_A[paper_idx][conflicted_reviewer_idx] == 0
+
+def test_solvers_pr4a_zero_scores():
+    '''No similarities while not allowing zero score assignments will raise an exception'''
+    aggregate_score_matrix_A = np.transpose(np.array([
+        [0, 0, 0],
+        [0, 0, 0],
+        [0, 0, 0],
+        [0, 0, 0]
+    ]))
+    constraint_matrix = np.zeros(np.shape(aggregate_score_matrix_A))
+    with pytest.raises(SolverException, match=r"4 members found with no affinity scores while not allowing zero score assignments"):
+            assert FairIR(
+                    [1, 1, 1, 1],
+                    [2, 2, 2, 2],
+                    [2,2,2],
+                    encoder(aggregate_score_matrix_A, constraint_matrix),
+                    allow_zero_score_assignments=False
+                )
+
+def test_solvers_pr4a_custom_demands():
+    """
+    Tests 3 papers, 4 reviewers.
+    Reviewers review min: 1, max: 2 papers.
+    Papers need [2,1,3] reviews.
+    No constraints.
+    Purpose: Assert that papers demands are matched.
+
+    Issue: PR4A does not support custom demands
+    """
+    aggregate_score_matrix_A = np.transpose(
+        np.array(
+            [
+                [0.2, 0.1, 0.4],
+                [0.5, 0.2, 0.3],
+                [0.2, 0.0, 0.6],
+                [0.7, 0.9, 0.3],
+            ]
+        )
+    )
+    constraint_matrix = np.zeros(np.shape(aggregate_score_matrix_A))
+    demands = [2, 1, 3]
+
+    with pytest.raises(SolverException, match=r'PR4A does not support custom paper demands, all demands must be the same'):
+            assert FairIR(
+                    [1, 1, 1, 1],
+                    [2, 2, 2, 2],
+                    demands,
+                    encoder(aggregate_score_matrix_A, constraint_matrix),
+                )
+
+def test_solvers_pr4a_custom_supply():
+    """
+    Tests 3 papers, 4 reviewers.
+    Reviewers review min: 1, max: [2,1,3,1] papers respectively.
+    Each papers needs 2 reviews.
+    No constraints.
+    Purpose: Assert that reviewers are assigned papers correctly based on their supply.
+    """
+    aggregate_score_matrix_A = np.transpose(
+        np.array(
+            [
+                [0.2, 0.1, 0.4],
+                [0.5, 0.2, 0.3],
+                [0.2, 0.0, 0.6],
+                [0.7, 0.9, 0.3],
+            ]
+        )
+    )
+    constraint_matrix = np.zeros(np.shape(aggregate_score_matrix_A))
+    demands = [2, 2, 2]
+    solver_A = FairIR(
+        [1, 1, 1, 1],
+        [2, 1, 3, 1],
+        demands,
+        encoder(aggregate_score_matrix_A, constraint_matrix),
+    )
+    res_A = solver_A.solve()
+    assert res_A.shape == (3, 4)
+    result = [assignments for assignments in np.sum(res_A, axis=1)]
+    assert_arrays(result, demands)
+
+def test_solver_pr4a_no_0_score_assignment():
+    """
+    Tests 5 papers, 4 reviewers.
+    Reviewers review min: 1, max: 3 papers.
+    Each paper needs 2 reviews.
+    Reviewer 0 cannot review paper 1.
+    Purpose: Assert that an assignment is never made for 0 or less score
+    """
+    aggregate_score_matrix = np.transpose(
+        np.array(
+            [
+                [-1, 1, 1, 0, 1],
+                [1, 0, -1, 0, 1],
+                [0, 1, 1, 1, 0],
+                [1, 1, 1, 1, 0],
+            ]
+        )
+    )
+    constraint_matrix = np.transpose(
+        np.array(
+            [
+                [0, -1, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+            ]
+        )
+    )
+
+    solver = FairIR(
+        [1, 1, 1, 1],
+        [3, 3, 3, 3],
+        [2, 2, 2, 2, 2],
+        encoder(aggregate_score_matrix, constraint_matrix),
+    )
+
+    res = solver.solve()
+    assert res.shape == (5, 4)
+    nrows, ncols = res.shape if len(res.shape) == 2 else (0, 0)
+    for i in range(nrows):
+        for j in range(ncols):
+            assert not (
+                aggregate_score_matrix[i, j] <= 0 and res[i, j] > 0
+            ), "Solution violates the rule for not making less than 0 score assignments at [{},{}]".format(
+                i, j
+            )

--- a/tests/test_solvers_fairir.py
+++ b/tests/test_solvers_fairir.py
@@ -5,13 +5,13 @@ import numpy as np
 from matcher.solvers import FairIR
 from conftest import assert_arrays
 
-encoder = namedtuple('Encoder', ['aggregate_score_matrix', 'constraint_matrix'])
+encoder = namedtuple('Encoder', ['aggregate_score_matrix', 'constraint_matrix', 'attribute_constraints'])
 
 def check_solution(solver, expected_cost):
     assert solver.optimal_cost == solver.cost, "Minimum cost solution is not the sum of the flows * unit cost in result matrix"
     assert solver.cost == expected_cost,  "Lowest cost solution should have cost = {}".format(expected_cost)
 
-def test_solvers_pr4a_random():
+def test_solvers_fairir_random():
     '''When costs are all zero, compute random assignments'''
     aggregate_score_matrix_A = np.transpose(np.array([
         [0, 0, 0],
@@ -24,13 +24,13 @@ def test_solvers_pr4a_random():
         [1,1,1,1],
         [2,2,2,2],
         [2,2,2],
-        encoder(aggregate_score_matrix_A, constraint_matrix)
+        encoder(aggregate_score_matrix_A, constraint_matrix, None)
     )
     res_A = solver_A.solve()
     print(res_A)
     assert res_A.shape == (3,4)
 
-def test_solvers_pr4a_simple_attribute_constraint():
+def test_solvers_fairir_simple_attribute_constraint():
     '''Test constraint that each paper must have reviewer[3] as a reviewer'''
     aggregate_score_matrix_A = np.transpose(np.array([
         [0, 0, 0],
@@ -39,17 +39,17 @@ def test_solvers_pr4a_simple_attribute_constraint():
         [0, 0, 0]
     ]))
     constraint_matrix = np.zeros(np.shape(aggregate_score_matrix_A))
-    solver_A = FairIR(
-        [0,0,0,0],
-        [2,2,2,3],
-        [2,2,2],
-        encoder(aggregate_score_matrix_A, constraint_matrix),
-        attr_constraints=[{
+    attr_constraints = [{
             'name': 'Seniority',
             'comparator': '<=',
             'bound': 1,
             'members': [3]
         }]
+    solver_A = FairIR(
+        [0,0,0,0],
+        [2,2,2,3],
+        [2,2,2],
+        encoder(aggregate_score_matrix_A, constraint_matrix, attr_constraints)
     )
     res_A = solver_A.solve()
     print(res_A)
@@ -57,7 +57,7 @@ def test_solvers_pr4a_simple_attribute_constraint():
         assert res_A[paper_idx][3] == 1
     assert res_A.shape == (3,4)
 
-def test_solvers_pr4a_structure_attribute_constraint():
+def test_solvers_fairir_structure_attribute_constraint():
     '''Test constraint that each paper must have reviewer[3] as a reviewer as well as obey similarity structure'''
     aggregate_score_matrix_A = np.transpose(np.array([
         [0.5, 0, 0],
@@ -66,17 +66,17 @@ def test_solvers_pr4a_structure_attribute_constraint():
         [0, 0, 0]
     ]))
     constraint_matrix = np.zeros(np.shape(aggregate_score_matrix_A))
-    solver_A = FairIR(
-        [0,0,0,0],
-        [2,2,2,3],
-        [2,2,2],
-        encoder(aggregate_score_matrix_A, constraint_matrix),
-        attr_constraints=[{
+    attr_constraints = [{
             'name': 'Seniority',
             'comparator': '<=',
             'bound': 1,
             'members': [3]
-        }]
+    }]
+    solver_A = FairIR(
+        [0,0,0,0],
+        [2,2,2,3],
+        [2,2,2],
+        encoder(aggregate_score_matrix_A, constraint_matrix, attr_constraints)
     )
     res_A = solver_A.solve()
     print(res_A)
@@ -88,7 +88,7 @@ def test_solvers_pr4a_structure_attribute_constraint():
     assert res_A[2][2] == 1
     assert res_A.shape == (3,4)
 
-def test_solvers_pr4a_attribute_constraint_over_similarity():
+def test_solvers_fairir_attribute_constraint_over_similarity():
     '''Test multiple constraint sets that go against highest similarity'''
     aggregate_score_matrix_A = np.transpose(np.array([
         [0.5, 0, 0],
@@ -97,12 +97,7 @@ def test_solvers_pr4a_attribute_constraint_over_similarity():
         [0, 0, 0.5]
     ]))
     constraint_matrix = np.zeros(np.shape(aggregate_score_matrix_A))
-    solver_A = FairIR(
-        [0,0,0,0],
-        [2,2,2,3],
-        [2,2,2],
-        encoder(aggregate_score_matrix_A, constraint_matrix),
-        attr_constraints=[{
+    attr_constraints = [{
             'name': 'constr1',
             'comparator': '<=',
             'bound': 1,
@@ -113,7 +108,12 @@ def test_solvers_pr4a_attribute_constraint_over_similarity():
             'comparator': '<=',
             'bound': 1,
             'members': [2, 3]
-        }]
+    }]
+    solver_A = FairIR(
+        [0,0,0,0],
+        [2,2,2,3],
+        [2,2,2],
+        encoder(aggregate_score_matrix_A, constraint_matrix, attr_constraints)
     )
     res_A = solver_A.solve()
     print(res_A)
@@ -121,7 +121,7 @@ def test_solvers_pr4a_attribute_constraint_over_similarity():
     assert bool(res_A[0][0] == 1) ^ bool(res_A[0][1] == 1)
     assert bool(res_A[2][2] == 1) ^ bool(res_A[2][3] == 1)
 
-def test_solvers_pr4a_conflict():
+def test_solvers_fairir_conflict():
     '''When reviewer[1] has conflicts with all papers, assert that no assignments were made to them'''
     conflicted_reviewer_idx = 1
 
@@ -141,7 +141,7 @@ def test_solvers_pr4a_conflict():
         [1,1,1,1],
         [2,2,2,2],
         [2,2,2],
-        encoder(aggregate_score_matrix_A, constraint_matrix)
+        encoder(aggregate_score_matrix_A, constraint_matrix, None)
     )
     res_A = solver_A.solve()
     print(res_A)
@@ -149,33 +149,13 @@ def test_solvers_pr4a_conflict():
     for paper_idx in range(3):
         assert res_A[paper_idx][conflicted_reviewer_idx] == 0
 
-def test_solvers_pr4a_zero_scores():
-    '''No similarities while not allowing zero score assignments will raise an exception'''
-    aggregate_score_matrix_A = np.transpose(np.array([
-        [0, 0, 0],
-        [0, 0, 0],
-        [0, 0, 0],
-        [0, 0, 0]
-    ]))
-    constraint_matrix = np.zeros(np.shape(aggregate_score_matrix_A))
-    with pytest.raises(SolverException, match=r"4 members found with no affinity scores while not allowing zero score assignments"):
-            assert FairIR(
-                    [1, 1, 1, 1],
-                    [2, 2, 2, 2],
-                    [2,2,2],
-                    encoder(aggregate_score_matrix_A, constraint_matrix),
-                    allow_zero_score_assignments=False
-                )
-
-def test_solvers_pr4a_custom_demands():
+def test_solvers_fairir_custom_demands():
     """
     Tests 3 papers, 4 reviewers.
     Reviewers review min: 1, max: 2 papers.
     Papers need [2,1,3] reviews.
     No constraints.
     Purpose: Assert that papers demands are matched.
-
-    Issue: PR4A does not support custom demands
     """
     aggregate_score_matrix_A = np.transpose(
         np.array(
@@ -189,16 +169,18 @@ def test_solvers_pr4a_custom_demands():
     )
     constraint_matrix = np.zeros(np.shape(aggregate_score_matrix_A))
     demands = [2, 1, 3]
+    solver_A = FairIR(
+        [1, 1, 1, 1],
+        [2, 2, 2, 2],
+        demands,
+        encoder(aggregate_score_matrix_A, constraint_matrix, None),
+    )
+    res_A = solver_A.solve()
+    assert res_A.shape == (3, 4)
+    result = [assignments for assignments in np.sum(res_A, axis=1)]
+    assert_arrays(result, demands)
 
-    with pytest.raises(SolverException, match=r'PR4A does not support custom paper demands, all demands must be the same'):
-            assert FairIR(
-                    [1, 1, 1, 1],
-                    [2, 2, 2, 2],
-                    demands,
-                    encoder(aggregate_score_matrix_A, constraint_matrix),
-                )
-
-def test_solvers_pr4a_custom_supply():
+def test_solvers_fairir_custom_supply():
     """
     Tests 3 papers, 4 reviewers.
     Reviewers review min: 1, max: [2,1,3,1] papers respectively.
@@ -222,56 +204,40 @@ def test_solvers_pr4a_custom_supply():
         [1, 1, 1, 1],
         [2, 1, 3, 1],
         demands,
-        encoder(aggregate_score_matrix_A, constraint_matrix),
+        encoder(aggregate_score_matrix_A, constraint_matrix, None),
     )
     res_A = solver_A.solve()
     assert res_A.shape == (3, 4)
     result = [assignments for assignments in np.sum(res_A, axis=1)]
     assert_arrays(result, demands)
 
-def test_solver_pr4a_no_0_score_assignment():
+def test_solvers_fairir_custom_demands_paper_with_0_demand():
     """
-    Tests 5 papers, 4 reviewers.
-    Reviewers review min: 1, max: 3 papers.
-    Each paper needs 2 reviews.
-    Reviewer 0 cannot review paper 1.
-    Purpose: Assert that an assignment is never made for 0 or less score
+    Tests 3 papers, 4 reviewers.
+    Reviewers review min: 0, max: 2 papers.
+    The 3 Papers need 2,1,0 reviews.
+    No constraints.
+    Purpose: Assert that reviewers demanding 0 papers get 0 assignments.
     """
-    aggregate_score_matrix = np.transpose(
+    aggregate_score_matrix_A = np.transpose(
         np.array(
             [
-                [-1, 1, 1, 0, 1],
-                [1, 0, -1, 0, 1],
-                [0, 1, 1, 1, 0],
-                [1, 1, 1, 1, 0],
+                [0.2, 0.1, 0.4],
+                [0.5, 0.2, 0.3],
+                [0.2, 0.0, 0.6],
+                [0.7, 0.9, 0.3],
             ]
         )
     )
-    constraint_matrix = np.transpose(
-        np.array(
-            [
-                [0, -1, 0, 0, 0],
-                [0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0],
-            ]
-        )
+    constraint_matrix = np.zeros(np.shape(aggregate_score_matrix_A))
+    demands = [2, 1, 0]
+    solver_A = FairIR(
+        [0, 0, 0, 0],
+        [2, 2, 2, 2],
+        demands,
+        encoder(aggregate_score_matrix_A, constraint_matrix, None),
     )
-
-    solver = FairIR(
-        [1, 1, 1, 1],
-        [3, 3, 3, 3],
-        [2, 2, 2, 2, 2],
-        encoder(aggregate_score_matrix, constraint_matrix),
-    )
-
-    res = solver.solve()
-    assert res.shape == (5, 4)
-    nrows, ncols = res.shape if len(res.shape) == 2 else (0, 0)
-    for i in range(nrows):
-        for j in range(ncols):
-            assert not (
-                aggregate_score_matrix[i, j] <= 0 and res[i, j] > 0
-            ), "Solution violates the rule for not making less than 0 score assignments at [{},{}]".format(
-                i, j
-            )
+    res_A = solver_A.solve()
+    assert res_A.shape == (3, 4)
+    result = [assignments for assignments in np.sum(res_A, axis=1)]
+    assert_arrays(result, demands)


### PR DESCRIPTION
This PR adds FairIR to the matcher and enables the use of Gurobi to support a number of a new type of constraint.

The API now accepts a new field in the assignment configuration note called `constraints_specification` and expects the following schema:

```
{
    edgeInvitationId: [
           { 
                "label": str,
                "min_users": int,
                "max_users": int
           }
    ]
}
```