### PR TITLE
filter paper by content

### DIFF
--- a/matcher/service/openreview_interface.py
+++ b/matcher/service/openreview_interface.py
@@ -820,15 +820,11 @@ class ConfigNoteInterfaceV2(BaseConfigNoteInterface):
                                 )
                             )
             if "/-/" in paper_invitation:
-                paper_notes = list(
-                    openreview.tools.iterget_notes(
-                        self.client,
-                        invitation=paper_invitation,
-                        content=content_dict,
-                    )
+                paper_notes = self.client.get_all_notes(
+                    invitation=paper_invitation
                 )
 
-                paper_notes = [self._content_to_api1(n) for n in paper_notes]
+                paper_notes = [self._content_to_api1(n) for n in paper_notes if self._match_content(n.content, content_dict)]
                 self._papers = [n.id for n in paper_notes]
                 self.paper_numbers = {n.id: n.number for n in paper_notes}
                 self.logger.debug(
@@ -921,6 +917,19 @@ class ConfigNoteInterfaceV2(BaseConfigNoteInterface):
             return property_params.get("param", {}).get("default", [])
 
         return []
+    
+    def _match_content(self, content, match_content):
+        if not match_content:
+            return True
+        
+        for name, value in match_content.items():
+
+            paper_value = content.get(name, {}).get('value')
+        
+            if paper_value != value:
+                return False
+        
+        return True    
 
 
 class Deployment:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -185,7 +185,7 @@ def clean_start_conference_v2(
                         "title": {
                             "value": "Test_Paper_{}".format(paper_number)
                         },
-                        "abstract": {"value": "Paper abstract"},
+                        "abstract": {"value": f"Paper abstract {paper_number}"},
                         "authors": {"value": authors},
                         "authorids": {"value": authorids},
                         "pdf": {"value": "/pdf/" + "p" * 40 + ".pdf"},

--- a/tests/test_integration_api2_fairflow.py
+++ b/tests/test_integration_api2_fairflow.py
@@ -1091,7 +1091,7 @@ def test_integration_group_with_email(
     )
     assert matcher_status.content["status"]["value"] == "Complete"
 
-def test_integration_by_track(openreview_context, celery_app, celery_worker):
+def test_integration_by_track(openreview_context, venue, celery_app, celery_session_worker):
     """
     Basic integration test. Makes use of the OpenReview Builder
     """
@@ -1099,26 +1099,15 @@ def test_integration_by_track(openreview_context, celery_app, celery_worker):
     openreview_client = openreview_context["openreview_client_v2"]
     test_client = openreview_context["test_client"]
 
-    conference_id = "AKBD.ws/2030/Conference"
-    num_reviewers = 10
-    num_papers = 10
     reviews_per_paper = 3
     max_papers = 5
     min_papers = 0
     alternates = 0
 
-    venue = clean_start_conference_v2(
-        openreview_client,
-        conference_id,
-        num_reviewers,
-        num_papers,
-        reviews_per_paper,
-    )
-
     reviewers_id = venue.get_reviewers_id()
 
     config = {
-        "title": {"value": "integration-test"},
+        "title": {"value": "integration-test-11"},
         "user_demand": {"value": str(reviews_per_paper)},
         "max_papers": {"value": str(max_papers)},
         "min_papers": {"value": str(min_papers)},
@@ -1176,11 +1165,74 @@ def test_integration_by_track(openreview_context, celery_app, celery_worker):
     matcher_status = wait_for_status(
         openreview_client, config_note["note"]["id"], api_version=2
     )
-    assert matcher_status.content["status"]["value"] == "Complete"
+    assert matcher_status.content["status"]["value"] == "Complete", matcher_status.content['error_message']['value']
 
     paper_assignment_edges = openreview_client.get_edges_count(
-        label="integration-test",
+        label="integration-test-11",
         invitation=venue.get_assignment_id(venue.get_reviewers_id()),
     )
 
     assert paper_assignment_edges == 3
+
+    config = {
+        "title": {"value": "integration-test-11"},
+        "user_demand": {"value": str(reviews_per_paper)},
+        "max_papers": {"value": str(max_papers)},
+        "min_papers": {"value": str(min_papers)},
+        "alternates": {"value": str(alternates)},
+        "config_invitation": {
+            "value": "{}/-/Assignment_Configuration".format(reviewers_id)
+        },
+        "paper_invitation": {"value": venue.get_submission_id() + '&content.track=Paper abstract 1'},
+        "assignment_invitation": {
+            "value": venue.get_assignment_id(reviewers_id)
+        },
+        "deployed_assignment_invitation": {
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
+        },
+        "invite_assignment_invitation": {
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
+        },
+        "aggregate_score_invitation": {
+            "value": "{}/-/Aggregate_Score".format(reviewers_id)
+        },
+        "conflicts_invitation": {
+            "value": venue.get_conflict_score_id(reviewers_id)
+        },
+        "custom_max_papers_invitation": {
+            "value": "{}/-/Custom_Max_Papers".format(reviewers_id)
+        },
+        "match_group": {"value": reviewers_id},
+        "scores_specification": {
+            "value": {
+                venue.get_affinity_score_id(reviewers_id): {
+                    "weight": 1.0,
+                    "default": 0.0,
+                }
+            }
+        },
+        "status": {"value": "Initialized"},
+        "solver": {"value": "FairFlow"},
+    }
+
+    config_note = openreview_client.post_note_edit(
+        invitation="{}/-/Assignment_Configuration".format(reviewers_id),
+        signatures=[venue.get_id()],
+        note=Note(content=config),
+    )
+    assert config_note
+
+    response = test_client.post(
+        "/match",
+        data=json.dumps({"configNoteId": config_note["note"]["id"]}),
+        content_type="application/json",
+        headers=openreview_client.headers,
+    )
+    assert response.status_code == 200
+
+    matcher_status = wait_for_status(
+        openreview_client, config_note["note"]["id"], api_version=2
+    )
+    assert matcher_status.content["status"]["value"] == "Error"
+    assert matcher_status.content['error_message']['value'] == "Papers List can not be empty."
+

--- a/tests/test_integration_api2_fairflow.py
+++ b/tests/test_integration_api2_fairflow.py
@@ -1090,3 +1090,97 @@ def test_integration_group_with_email(
         openreview_client, config_note["note"]["id"], api_version=2
     )
     assert matcher_status.content["status"]["value"] == "Complete"
+
+def test_integration_by_track(openreview_context, celery_app, celery_worker):
+    """
+    Basic integration test. Makes use of the OpenReview Builder
+    """
+
+    openreview_client = openreview_context["openreview_client_v2"]
+    test_client = openreview_context["test_client"]
+
+    conference_id = "AKBD.ws/2030/Conference"
+    num_reviewers = 10
+    num_papers = 10
+    reviews_per_paper = 3
+    max_papers = 5
+    min_papers = 0
+    alternates = 0
+
+    venue = clean_start_conference_v2(
+        openreview_client,
+        conference_id,
+        num_reviewers,
+        num_papers,
+        reviews_per_paper,
+    )
+
+    reviewers_id = venue.get_reviewers_id()
+
+    config = {
+        "title": {"value": "integration-test"},
+        "user_demand": {"value": str(reviews_per_paper)},
+        "max_papers": {"value": str(max_papers)},
+        "min_papers": {"value": str(min_papers)},
+        "alternates": {"value": str(alternates)},
+        "config_invitation": {
+            "value": "{}/-/Assignment_Configuration".format(reviewers_id)
+        },
+        "paper_invitation": {"value": venue.get_submission_id() + '&content.abstract=Paper abstract 1'},
+        "assignment_invitation": {
+            "value": venue.get_assignment_id(reviewers_id)
+        },
+        "deployed_assignment_invitation": {
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
+        },
+        "invite_assignment_invitation": {
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
+        },
+        "aggregate_score_invitation": {
+            "value": "{}/-/Aggregate_Score".format(reviewers_id)
+        },
+        "conflicts_invitation": {
+            "value": venue.get_conflict_score_id(reviewers_id)
+        },
+        "custom_max_papers_invitation": {
+            "value": "{}/-/Custom_Max_Papers".format(reviewers_id)
+        },
+        "match_group": {"value": reviewers_id},
+        "scores_specification": {
+            "value": {
+                venue.get_affinity_score_id(reviewers_id): {
+                    "weight": 1.0,
+                    "default": 0.0,
+                }
+            }
+        },
+        "status": {"value": "Initialized"},
+        "solver": {"value": "FairFlow"},
+    }
+
+    config_note = openreview_client.post_note_edit(
+        invitation="{}/-/Assignment_Configuration".format(reviewers_id),
+        signatures=[venue.get_id()],
+        note=Note(content=config),
+    )
+    assert config_note
+
+    response = test_client.post(
+        "/match",
+        data=json.dumps({"configNoteId": config_note["note"]["id"]}),
+        content_type="application/json",
+        headers=openreview_client.headers,
+    )
+    assert response.status_code == 200
+
+    matcher_status = wait_for_status(
+        openreview_client, config_note["note"]["id"], api_version=2
+    )
+    assert matcher_status.content["status"]["value"] == "Complete"
+
+    paper_assignment_edges = openreview_client.get_edges_count(
+        label="integration-test",
+        invitation=venue.get_assignment_id(venue.get_reviewers_id()),
+    )
+
+    assert paper_assignment_edges == 3


### PR DESCRIPTION
- Filter submissions by any field of the content. Don't pass the content filters to the API call and filter them locally.
- Replace iterget_notes with get_all_notes