### PR TITLE
FairIR: Fix Multiple Attributes

### DIFF
--- a/matcher/service/openreview_interface.py
+++ b/matcher/service/openreview_interface.py
@@ -275,7 +275,7 @@ class BaseConfigNoteInterface:
                     if len(members) < 1:
                         raise openreview.OpenReviewException(f"{name}/{label} has no corresponding members")
 
-                    self._attribute_constraints['name'] = {
+                    self._attribute_constraints[f"{name}/{label}"] = {
                             'comparator': comparator,
                             'bound': bound,
                             'members': members

--- a/tests/test_integration_api2_fairir.py
+++ b/tests/test_integration_api2_fairir.py
@@ -264,6 +264,192 @@ def test_integration_attribute_constraints(
 
     assert paper_assignment_edges == num_papers * reviews_per_paper
 
+def test_integration_many_attribute_constraints(
+    openreview_context, celery_app, celery_session_worker
+):
+    """
+    Tests multiple edge values in a single invitation for attribute constraints
+    """
+    openreview_client = openreview_context["openreview_client_v2"]
+    test_client = openreview_context["test_client"]
+
+    conference_id = "IMCLR.ws/2027/Conference"
+    num_reviewers = 3
+    num_papers = 1
+    reviews_per_paper = 3
+    max_papers = 1
+    min_papers = 0
+    alternates = 0
+
+    venue = clean_start_conference_v2(
+        openreview_client,
+        conference_id,
+        num_reviewers,
+        num_papers,
+        reviews_per_paper,
+    )
+
+    post_fairir_to_api2(openreview_client, conference_id)
+
+    reviewers_id = venue.get_reviewers_id()
+    region_inv_id = "{}/-/Region".format(reviewers_id)
+
+    config = {
+        "title": {"value": "integration-test-constraints"},
+        "user_demand": {"value": str(reviews_per_paper)},
+        "max_papers": {"value": str(max_papers)},
+        "min_papers": {"value": str(min_papers)},
+        "alternates": {"value": str(alternates)},
+        "config_invitation": {
+            "value": "{}/-/Assignment_Configuration".format(reviewers_id)
+        },
+        "paper_invitation": {"value": venue.get_submission_id()},
+        "assignment_invitation": {
+            "value": venue.get_assignment_id(reviewers_id)
+        },
+        "deployed_assignment_invitation": {
+            "value": venue.get_assignment_id(reviewers_id, deployed=True)
+        },
+        "invite_assignment_invitation": {
+            "value": venue.get_assignment_id(reviewers_id, invite=True)
+        },
+        "aggregate_score_invitation": {
+            "value": "{}/-/Aggregate_Score".format(reviewers_id)
+        },
+        "conflicts_invitation": {
+            "value": venue.get_conflict_score_id(reviewers_id)
+        },
+        "custom_max_papers_invitation": {
+            "value": "{}/-/Custom_Max_Papers".format(reviewers_id)
+        },
+        "match_group": {"value": reviewers_id},
+        "scores_specification": {
+            "value": {
+                venue.get_affinity_score_id(reviewers_id): {
+                    "weight": 1.0,
+                    "default": 0.0,
+                }
+            }
+        },
+        "constraints_specification": {
+            "value": {
+                region_inv_id: [
+                    { 
+                        "label": "US",
+                        "max_users": 1
+                    },
+                    { 
+                        "label": "EU",
+                        "min_users": 1
+                    }
+                ]
+            }
+        },
+        "status": {"value": "Initialized"},
+        "solver": {"value": "FairIR"},
+    }
+    # Post Seniority edge invitation
+    venue_matching = openreview.venue.matching.Matching(venue, openreview_client.get_group(reviewers_id), None)
+    venue_matching._create_edge_invitation(region_inv_id)
+
+    inv = openreview_client.get_invitation(region_inv_id)
+    inv.edit['head'] = {
+        'param': {
+            'type': 'group',
+            'const': reviewers_id
+        }
+    }
+    openreview_client.post_invitation_edit(
+        invitations=f"{conference_id}/-/Edit",
+        readers=[conference_id],
+        writers=[conference_id],
+        signatures=[conference_id],
+        replacement=False,
+        invitation=inv
+    )
+
+    us_reviewer1 = openreview_client.get_group(reviewers_id).members[0]
+    us_edge1 = openreview.api.Edge(
+        head=reviewers_id,
+        tail=us_reviewer1,
+        invitation=region_inv_id,
+        readers=venue_matching._get_edge_readers(reviewers_id),
+        writers=[venue.id],
+        signatures=[venue.id],
+        label='US',
+        weight=1
+    )
+
+    us_reviewer2 = openreview_client.get_group(reviewers_id).members[1]
+    us_edge2 = openreview.api.Edge(
+        head=reviewers_id,
+        tail=us_reviewer2,
+        invitation=region_inv_id,
+        readers=venue_matching._get_edge_readers(reviewers_id),
+        writers=[venue.id],
+        signatures=[venue.id],
+        label='US',
+        weight=1
+    )
+
+    eu_reviewer = openreview_client.get_group(reviewers_id).members[2]
+    eu_edge = openreview.api.Edge(
+        head=reviewers_id,
+        tail=eu_reviewer,
+        invitation=region_inv_id,
+        readers=venue_matching._get_edge_readers(reviewers_id),
+        writers=[venue.id],
+        signatures=[venue.id],
+        label='EU',
+        weight=1
+    )
+
+    openreview.tools.post_bulk_edges(client=openreview_client, edges=[us_edge1, us_edge2, eu_edge])
+
+    print(openreview_client.get_grouped_edges(invitation=region_inv_id, groupby='id'))
+
+    config_note = openreview_client.post_note_edit(
+        invitation="{}/-/Assignment_Configuration".format(reviewers_id),
+        signatures=[venue.get_id()],
+        note=Note(content=config),
+    )
+    assert config_note
+
+    response = test_client.post(
+        "/match",
+        data=json.dumps({"configNoteId": config_note["note"]["id"]}),
+        content_type="application/json",
+        headers=openreview_client.headers,
+    )
+    assert response.status_code == 200
+
+    matcher_status = wait_for_status(
+        openreview_client, config_note["note"]["id"], api_version=2
+    )
+    assert matcher_status.content["status"]["value"] == "Complete"
+
+    paper_assignment_edges = openreview_client.get_edges_count(
+        label="integration-test-constraints",
+        invitation=venue.get_assignment_id(venue.get_reviewers_id()),
+    )
+
+    assert paper_assignment_edges == num_papers * reviews_per_paper
+
+    grouped_edges = openreview_client.get_grouped_edges(
+        label="integration-test-constraints",
+        invitation=venue.get_assignment_id(
+            venue.get_reviewers_id()
+        ),
+        groupby='head',
+        select='id,head,tail'
+    )
+
+    for edge_dict in grouped_edges:
+        assert sum([1 for edge in edge_dict['values'] if us_reviewer1 == edge['tail'] or us_reviewer2 == edge['tail']]) <= 1, f"Too many US reviewers"
+        assert True in [eu_reviewer == edge['tail'] for edge in edge_dict['values']], f"No EU reviewer found"
+
+    assert paper_assignment_edges == num_papers * reviews_per_paper
+
 def test_integration_supply_mismatch_error(
     openreview_context, celery_app, celery_session_worker
 ):

--- a/tests/test_integration_api2_fairir.py
+++ b/tests/test_integration_api2_fairir.py
@@ -348,7 +348,7 @@ def test_integration_many_attribute_constraints(
         "status": {"value": "Initialized"},
         "solver": {"value": "FairIR"},
     }
-    # Post Seniority edge invitation
+    # Post Region edge invitation
     venue_matching = openreview.venue.matching.Matching(venue, openreview_client.get_group(reviewers_id), None)
     venue_matching._create_edge_invitation(region_inv_id)
 
@@ -426,29 +426,14 @@ def test_integration_many_attribute_constraints(
     matcher_status = wait_for_status(
         openreview_client, config_note["note"]["id"], api_version=2
     )
-    assert matcher_status.content["status"]["value"] == "Complete"
+    assert matcher_status.content["status"]["value"] == "Error"
 
     paper_assignment_edges = openreview_client.get_edges_count(
         label="integration-test-constraints",
         invitation=venue.get_assignment_id(venue.get_reviewers_id()),
     )
 
-    assert paper_assignment_edges == num_papers * reviews_per_paper
-
-    grouped_edges = openreview_client.get_grouped_edges(
-        label="integration-test-constraints",
-        invitation=venue.get_assignment_id(
-            venue.get_reviewers_id()
-        ),
-        groupby='head',
-        select='id,head,tail'
-    )
-
-    for edge_dict in grouped_edges:
-        assert sum([1 for edge in edge_dict['values'] if us_reviewer1 == edge['tail'] or us_reviewer2 == edge['tail']]) <= 1, f"Too many US reviewers"
-        assert True in [eu_reviewer == edge['tail'] for edge in edge_dict['values']], f"No EU reviewer found"
-
-    assert paper_assignment_edges == num_papers * reviews_per_paper
+    assert paper_assignment_edges == 0
 
 def test_integration_supply_mismatch_error(
     openreview_context, celery_app, celery_session_worker


### PR DESCRIPTION
This PR fixes an issue where only the last attribute constraint parsed from the API using edges would be stored, instead of all constraints.