### PR TITLE
Fix: Re-word logger errors

### DIFF
--- a/matcher/core.py
+++ b/matcher/core.py
@@ -231,7 +231,7 @@ class Matcher:
                 )
                 self.set_status(
                     MatcherStatus.NO_SOLUTION,
-                    message="Solver could not find a solution. Adjust your parameters",
+                    message="Solver could not find a solution. Try (1) increasing max papers (2) adding more reviewers or (3) using only more recent history for computing conflicts in the Paper Matching Setup to reduce conflicts.",
                 )
 
         except SolverException as error_handle:

--- a/matcher/solvers/fairflow.py
+++ b/matcher/solvers/fairflow.py
@@ -137,9 +137,9 @@ class FairFlow(object):
 
         if demand > max_supply or demand < min_supply:
             raise SolverException(
-                "Total demand ({}) is out of range when min review supply is ({}) and max review supply is ({})".format(
+                "Review demand ({}) must be between the min review supply is ({}) and max review supply is ({}).".format(
                     demand, min_supply, max_supply
-                )
+                ) + " Try (1) decreasing min papers (2) increasing max papers or (3) finding more reviewers"
             )
 
         self.logger.debug("Finished checking graph inputs")
@@ -631,10 +631,7 @@ class FairFlow(object):
             self.solved = True
         else:
             raise SolverException(
-                "Solver could not find a solution. Adjust your parameters. "
-                "[_construct_graph_and_solve] SOLVER_STATUS: {}".format(
-                    solver_status
-                )
+                "Solver could not find a solution. Try (1) increasing max papers (2) adding more reviewers or (3) using only more recent history for computing conflicts in the Paper Matching Setup to reduce conflicts."
             )
 
     def find_ms(self):

--- a/matcher/solvers/fairir.py
+++ b/matcher/solvers/fairir.py
@@ -276,9 +276,9 @@ class FairIR(Basic):
 
         if demand > max_supply or demand < min_supply:
             raise SolverException(
-                "Total demand ({}) is out of range when min review supply is ({}) and max review supply is ({})".format(
+                "Review demand ({}) must be between the min review supply is ({}) and max review supply is ({}).".format(
                     demand, min_supply, max_supply
-                )
+                ) + " Try (1) decreasing min papers (2) increasing max papers or (3) finding more reviewers"
             )
 
         self._log_and_profile("Finished checking graph inputs")
@@ -627,4 +627,4 @@ class FairIR(Basic):
                 return
         
         if not solved:
-            raise Exception('No Solution.')
+            raise Exception("Solver could not find a solution. Try (1) increasing max papers (2) adding more reviewers or (3) using only more recent history for computing conflicts in the Paper Matching Setup to reduce conflicts.")

--- a/matcher/solvers/fairsequence.py
+++ b/matcher/solvers/fairsequence.py
@@ -131,9 +131,9 @@ class FairSequence(object):
 
         if demand > max_supply or demand < min_supply:
             raise SolverException(
-                "Total demand ({}) is out of range when min review supply is ({}) and max review supply is ({})".format(
+                "Review demand ({}) must be between the min review supply is ({}) and max review supply is ({}).".format(
                     demand, min_supply, max_supply
-                )
+                ) + " Try (1) decreasing min papers (2) increasing max papers or (3) finding more reviewers"
             )
 
         self.logger.debug("Finished checking input ranges")
@@ -621,7 +621,7 @@ class FairSequence(object):
                 )
             except PickingSequenceException:
                 raise SolverException(
-                    "Solver could not find a solution. Adjust your parameters."
+                    "Solver could not find a solution. Try (1) increasing max papers (2) adding more reviewers or (3) using only more recent history for computing conflicts in the Paper Matching Setup to reduce conflicts."
                 )
 
         if improper_papers:

--- a/matcher/solvers/minmax_solver.py
+++ b/matcher/solvers/minmax_solver.py
@@ -90,9 +90,9 @@ class MinMaxSolver:
 
         if demand > max_supply or demand < min_supply:
             raise SolverException(
-                "Total demand ({}) is out of range when min review supply is ({}) and max review supply is ({})".format(
+                "Review demand ({}) must be between the min review supply is ({}) and max review supply is ({}).".format(
                     demand, min_supply, max_supply
-                )
+                ) + " Try (1) decreasing min papers (2) increasing max papers or (3) finding more reviewers"
             )
 
         self.logger.debug("Finished checking graph inputs")

--- a/matcher/solvers/perturbed_maximization_solver.py
+++ b/matcher/solvers/perturbed_maximization_solver.py
@@ -345,9 +345,9 @@ class PerturbedMaximizationSolver:
 
         if demand > max_supply or demand < min_supply:
             raise SolverException(
-                "Total demand ({}) is out of range when min review supply is ({}) and max review supply is ({})".format(
+                "Review demand ({}) must be between the min review supply is ({}) and max review supply is ({}).".format(
                     demand, min_supply, max_supply
-                )
+                ) + " Try (1) decreasing min papers (2) increasing max papers or (3) finding more reviewers"
             )
 
         self.logger.debug("[PerturbedMaximization]: Finished checking inputs")

--- a/matcher/solvers/randomized_solver.py
+++ b/matcher/solvers/randomized_solver.py
@@ -162,9 +162,9 @@ class RandomizedSolver:
 
         if demand > max_supply or demand < min_supply:
             raise SolverException(
-                "Total demand ({}) is out of range when min review supply is ({}) and max review supply is ({})".format(
+                "Review demand ({}) must be between the min review supply is ({}) and max review supply is ({}).".format(
                     demand, min_supply, max_supply
-                )
+                ) + " Try (1) decreasing min papers (2) increasing max papers or (3) finding more reviewers"
             )
 
         self.logger.debug("Finished checking if demand is in range")

--- a/tests/test_integration_api2_fairflow.py
+++ b/tests/test_integration_api2_fairflow.py
@@ -193,7 +193,7 @@ def test_integration_supply_mismatch_error(
     assert matcher_status.content["status"]["value"] == "No Solution"
     assert (
         matcher_status.content["error_message"]["value"]
-        == "Total demand (100) is out of range when min review supply is (10) and max review supply is (10)"
+        == "Review demand (100) must be between the min review supply is (10) and max review supply is (10). Try (1) decreasing min papers (2) increasing max papers or (3) finding more reviewers"
     )
 
     paper_assignment_edges = openreview_client.get_edges_count(
@@ -381,7 +381,7 @@ def test_integration_demand_out_of_supply_range_error(
     assert matcher_status.content["status"]["value"] == "No Solution"
     assert (
         matcher_status.content["error_message"]["value"]
-        == "Total demand (30) is out of range when min review supply is (40) and max review supply is (50)"
+        == "Review demand (30) must be between the min review supply is (40) and max review supply is (50). Try (1) decreasing min papers (2) increasing max papers or (3) finding more reviewers"
     )
 
     paper_assignment_edges = openreview_client.get_edges_count(

--- a/tests/test_integration_api2_fairir.py
+++ b/tests/test_integration_api2_fairir.py
@@ -639,7 +639,7 @@ def test_integration_supply_mismatch_error(
     assert matcher_status.content["status"]["value"] == "No Solution"
     assert (
         matcher_status.content["error_message"]["value"]
-        == "Total demand (100) is out of range when min review supply is (10) and max review supply is (10)"
+        == "Review demand (100) must be between the min review supply is (10) and max review supply is (10). Try (1) decreasing min papers (2) increasing max papers or (3) finding more reviewers"
     )
 
     paper_assignment_edges = openreview_client.get_edges_count(
@@ -741,7 +741,7 @@ def test_integration_demand_out_of_supply_range_error(
     assert matcher_status.content["status"]["value"] == "No Solution"
     assert (
         matcher_status.content["error_message"]["value"]
-        == "Total demand (30) is out of range when min review supply is (40) and max review supply is (50)"
+        == "Review demand (30) must be between the min review supply is (40) and max review supply is (50). Try (1) decreasing min papers (2) increasing max papers or (3) finding more reviewers"
     )
 
     paper_assignment_edges = openreview_client.get_edges_count(

--- a/tests/test_integration_api2_fairsequence.py
+++ b/tests/test_integration_api2_fairsequence.py
@@ -195,7 +195,7 @@ def test_integration_supply_mismatch_error(
     assert matcher_status.content["status"]["value"] == "No Solution"
     assert (
         matcher_status.content["error_message"]["value"]
-        == "Total demand (100) is out of range when min review supply is (10) and max review supply is (10)"
+        == "Review demand (100) must be between the min review supply is (10) and max review supply is (10). Try (1) decreasing min papers (2) increasing max papers or (3) finding more reviewers"
     )
 
     paper_assignment_edges = openreview_client.get_edges_count(
@@ -295,7 +295,7 @@ def test_integration_demand_out_of_supply_range_error(
     assert matcher_status.content["status"]["value"] == "No Solution"
     assert (
         matcher_status.content["error_message"]["value"]
-        == "Total demand (30) is out of range when min review supply is (40) and max review supply is (50)"
+        == "Review demand (30) must be between the min review supply is (40) and max review supply is (50). Try (1) decreasing min papers (2) increasing max papers or (3) finding more reviewers"
     )
 
     paper_assignment_edges = openreview_client.get_edges_count(

--- a/tests/test_integration_api2_minmax.py
+++ b/tests/test_integration_api2_minmax.py
@@ -209,7 +209,7 @@ def test_integration_no_solution_due_to_conflicts(
     assert matcher_status.content["status"]["value"] == "No Solution"
     assert (
         matcher_status.content["error_message"]["value"]
-        == "Solver could not find a solution. Adjust your parameters"
+        == "Solver could not find a solution. Try (1) increasing max papers (2) adding more reviewers or (3) using only more recent history for computing conflicts in the Paper Matching Setup to reduce conflicts."
     )
 
     paper_assignment_edges = openreview_client.get_edges_count(
@@ -309,7 +309,7 @@ def test_integration_supply_mismatch_error(
     assert matcher_status.content["status"]["value"] == "No Solution"
     assert (
         matcher_status.content["error_message"]["value"]
-        == "Total demand (100) is out of range when min review supply is (10) and max review supply is (10)"
+        == "Review demand (100) must be between the min review supply is (10) and max review supply is (10). Try (1) decreasing min papers (2) increasing max papers or (3) finding more reviewers"
     )
 
     paper_assignment_edges = openreview_client.get_edges_count(
@@ -409,7 +409,7 @@ def test_integration_demand_out_of_supply_range_error(
     assert matcher_status.content["status"]["value"] == "No Solution"
     assert (
         matcher_status.content["error_message"]["value"]
-        == "Total demand (30) is out of range when min review supply is (40) and max review supply is (50)"
+        == "Review demand (30) must be between the min review supply is (40) and max review supply is (50). Try (1) decreasing min papers (2) increasing max papers or (3) finding more reviewers"
     )
 
     paper_assignment_edges = openreview_client.get_edges_count(

--- a/tests/test_integration_api2_perturbed_maximization.py
+++ b/tests/test_integration_api2_perturbed_maximization.py
@@ -195,7 +195,7 @@ def test_integration_supply_mismatch_error(
     assert matcher_status.content["status"]["value"] == "No Solution"
     assert (
         matcher_status.content["error_message"]["value"]
-        == "Total demand (100) is out of range when min review supply is (10) and max review supply is (10)"
+        == "Review demand (100) must be between the min review supply is (10) and max review supply is (10). Try (1) decreasing min papers (2) increasing max papers or (3) finding more reviewers"
     )
 
     paper_assignment_edges = openreview_client.get_edges_count(
@@ -383,7 +383,7 @@ def test_integration_demand_out_of_supply_range_error(
     assert matcher_status.content["status"]["value"] == "No Solution"
     assert (
         matcher_status.content["error_message"]["value"]
-        == "Total demand (30) is out of range when min review supply is (40) and max review supply is (50)"
+        == "Review demand (30) must be between the min review supply is (40) and max review supply is (50). Try (1) decreasing min papers (2) increasing max papers or (3) finding more reviewers"
     )
 
     paper_assignment_edges = openreview_client.get_edges_count(

--- a/tests/test_integration_api2_randomized.py
+++ b/tests/test_integration_api2_randomized.py
@@ -201,7 +201,7 @@ def test_integration_supply_mismatch_error(
     assert matcher_status.content["status"]["value"] == "No Solution"
     assert (
         matcher_status.content["error_message"]["value"]
-        == "Total demand (100) is out of range when min review supply is (10) and max review supply is (10)"
+        == "Review demand (100) must be between the min review supply is (10) and max review supply is (10). Try (1) decreasing min papers (2) increasing max papers or (3) finding more reviewers"
     )
 
     paper_assignment_edges = openreview_client.get_edges_count(
@@ -301,7 +301,7 @@ def test_integration_demand_out_of_supply_range_error(
     assert matcher_status.content["status"]["value"] == "No Solution"
     assert (
         matcher_status.content["error_message"]["value"]
-        == "Total demand (30) is out of range when min review supply is (40) and max review supply is (50)"
+        == "Review demand (30) must be between the min review supply is (40) and max review supply is (50). Try (1) decreasing min papers (2) increasing max papers or (3) finding more reviewers"
     )
 
     paper_assignment_edges = openreview_client.get_edges_count(

--- a/tests/test_integration_fairflow.py
+++ b/tests/test_integration_fairflow.py
@@ -195,7 +195,7 @@ def test_integration_supply_mismatch_error(
     assert matcher_status.content["status"] == "No Solution"
     assert (
         matcher_status.content["error_message"]
-        == "Total demand (200) is out of range when min review supply is (10) and max review supply is (10)"
+        == "Review demand (200) must be between the min review supply is (10) and max review supply is (10). Try (1) decreasing min papers (2) increasing max papers or (3) finding more reviewers"
     )
 
     paper_assignment_edges = openreview_client.get_edges_count(
@@ -398,7 +398,7 @@ def test_integration_demand_out_of_supply_range_error(
     assert matcher_status.content["status"] == "No Solution"
     assert (
         matcher_status.content["error_message"]
-        == "Total demand (30) is out of range when min review supply is (40) and max review supply is (50)"
+        == "Review demand (30) must be between the min review supply is (40) and max review supply is (50). Try (1) decreasing min papers (2) increasing max papers or (3) finding more reviewers"
     )
 
     paper_assignment_edges = openreview_client.get_edges_count(

--- a/tests/test_integration_fairir.py
+++ b/tests/test_integration_fairir.py
@@ -198,7 +198,7 @@ def test_integration_supply_mismatch_error(
     assert matcher_status.content["status"] == "No Solution"
     assert (
         matcher_status.content["error_message"]
-        == "Total demand (100) is out of range when min review supply is (10) and max review supply is (10)"
+        == "Review demand (100) must be between the min review supply is (10) and max review supply is (10). Try (1) decreasing min papers (2) increasing max papers or (3) finding more reviewers"
     )
 
     paper_assignment_edges = openreview_client.get_edges_count(
@@ -448,7 +448,7 @@ def test_integration_demand_out_of_supply_range_error(
     assert matcher_status.content["status"] == "No Solution"
     assert (
         matcher_status.content["error_message"]
-        == "Total demand (30) is out of range when min review supply is (40) and max review supply is (50)"
+        == "Review demand (30) must be between the min review supply is (40) and max review supply is (50). Try (1) decreasing min papers (2) increasing max papers or (3) finding more reviewers"
     )
 
     paper_assignment_edges = openreview_client.get_edges_count(

--- a/tests/test_integration_fairsequence.py
+++ b/tests/test_integration_fairsequence.py
@@ -195,7 +195,7 @@ def test_integration_supply_mismatch_error(
     assert matcher_status.content["status"] == "No Solution"
     assert (
         matcher_status.content["error_message"]
-        == "Total demand (100) is out of range when min review supply is (10) and max review supply is (10)"
+        == "Review demand (100) must be between the min review supply is (10) and max review supply is (10). Try (1) decreasing min papers (2) increasing max papers or (3) finding more reviewers"
     )
 
     paper_assignment_edges = openreview_client.get_edges_count(
@@ -297,7 +297,7 @@ def test_integration_demand_out_of_supply_range_error(
     assert matcher_status.content["status"] == "No Solution"
     assert (
         matcher_status.content["error_message"]
-        == "Total demand (30) is out of range when min review supply is (40) and max review supply is (50)"
+        == "Review demand (30) must be between the min review supply is (40) and max review supply is (50). Try (1) decreasing min papers (2) increasing max papers or (3) finding more reviewers"
     )
 
     paper_assignment_edges = openreview_client.get_edges_count(

--- a/tests/test_integration_minmax.py
+++ b/tests/test_integration_minmax.py
@@ -213,7 +213,7 @@ def test_integration_no_solution_due_to_conflicts(
     assert matcher_status.content["status"] == "No Solution"
     assert (
         matcher_status.content["error_message"]
-        == "Solver could not find a solution. Adjust your parameters"
+        == "Solver could not find a solution. Try (1) increasing max papers (2) adding more reviewers or (3) using only more recent history for computing conflicts in the Paper Matching Setup to reduce conflicts."
     )
 
     paper_assignment_edges = openreview_client.get_edges_count(
@@ -315,7 +315,7 @@ def test_integration_supply_mismatch_error(
     assert matcher_status.content["status"] == "No Solution"
     assert (
         matcher_status.content["error_message"]
-        == "Total demand (100) is out of range when min review supply is (10) and max review supply is (10)"
+        == "Review demand (100) must be between the min review supply is (10) and max review supply is (10). Try (1) decreasing min papers (2) increasing max papers or (3) finding more reviewers"
     )
 
     paper_assignment_edges = openreview_client.get_edges_count(
@@ -417,7 +417,7 @@ def test_integration_demand_out_of_supply_range_error(
     assert matcher_status.content["status"] == "No Solution"
     assert (
         matcher_status.content["error_message"]
-        == "Total demand (30) is out of range when min review supply is (40) and max review supply is (50)"
+        == "Review demand (30) must be between the min review supply is (40) and max review supply is (50). Try (1) decreasing min papers (2) increasing max papers or (3) finding more reviewers"
     )
 
     paper_assignment_edges = openreview_client.get_edges_count(

--- a/tests/test_integration_randomized.py
+++ b/tests/test_integration_randomized.py
@@ -202,7 +202,7 @@ def test_integration_supply_mismatch_error(
     assert matcher_status.content["status"] == "No Solution"
     assert (
         matcher_status.content["error_message"]
-        == "Total demand (100) is out of range when min review supply is (10) and max review supply is (10)"
+        == "Review demand (100) must be between the min review supply is (10) and max review supply is (10). Try (1) decreasing min papers (2) increasing max papers or (3) finding more reviewers"
     )
 
     paper_assignment_edges = openreview_client.get_edges_count(
@@ -304,7 +304,7 @@ def test_integration_demand_out_of_supply_range_error(
     assert matcher_status.content["status"] == "No Solution"
     assert (
         matcher_status.content["error_message"]
-        == "Total demand (30) is out of range when min review supply is (40) and max review supply is (50)"
+        == "Review demand (30) must be between the min review supply is (40) and max review supply is (50). Try (1) decreasing min papers (2) increasing max papers or (3) finding more reviewers"
     )
 
     paper_assignment_edges = openreview_client.get_edges_count(

--- a/tests/test_solvers_fairsequence.py
+++ b/tests/test_solvers_fairsequence.py
@@ -825,7 +825,7 @@ def test_solver_fairsequence_avoid_zero_scores_get_no_solution():
 
     with pytest.raises(
         SolverException,
-        match=r"Solver could not find a solution. Adjust your parameters.",
+        match=r"Solver could not find a solution",
     ):
         res = solver.solve()
 


### PR DESCRIPTION
This PR changes some of the common errors returned to the frontend on the assignments page:

1. `Solver could not find a solution. Adjust your parameters`, `Solver could not find a solution. Adjust your parameters. [_construct_graph_and_solve] SOLVER_STATUS: {}` -> `Solver could not find a solution. Try (1) increasing max papers (2) adding more reviewers or (3) using only more recent history for computing conflicts in the Paper Matching Setup to reduce conflicts.`
2. `Total demand ({}) is out of range when min review supply is ({}) and max review supply is ({})` -> `Review demand ({}) must be between the min review supply is ({}) and max review supply is ({}). Try (1) decreasing min papers (2) increasing max papers or (3) finding more reviewers`