### PR TITLE
fix check inputs, disallow negative scores, update default thresholds

### DIFF
--- a/matcher/__main__.py
+++ b/matcher/__main__.py
@@ -96,8 +96,8 @@ parser.add_argument(
         One or more floating numbers representing the thresholds in affinity score
         for categorizing a paper-reviewer match. The Perturbed Maximization Solver 
         uses these thresholds, and tries to randomize the assignment within the
-        threshold range. E.g., 0.1, 0.3, 0.5 means that the solver will try to 
-        randomize within [0, 0.1), [0.1, 0.3), [0.3, 0.5), [0.5, 1.0] score ranges.
+        threshold range. E.g., 0.1, 0.5, 1.0 means that the solver will try to 
+        randomize within [0, 0.1), [0.1, 0.5), [0.5, 1.0), [1.0, +inf) score ranges.
         """,
 )
 

--- a/matcher/service/openreview_interface.py
+++ b/matcher/service/openreview_interface.py
@@ -586,7 +586,7 @@ class ConfigNoteInterfaceV1(BaseConfigNoteInterface):
             self.config_note.content.get("perturbedmaximization_perturbation", 0.0)
         )
         self.bad_match_thresholds = self.config_note.content.get(
-            "perturbedmaximization_bad_match_thresholds", [0.1, 0.3, 0.5]
+            "perturbedmaximization_bad_match_thresholds", [0.1, 0.5, 1.0]
         )
 
         # Lazy variables
@@ -789,7 +789,7 @@ class ConfigNoteInterfaceV2(BaseConfigNoteInterface):
             self.config_note.content.get("perturbedmaximization_perturbation", 0.0)
         )
         self.bad_match_thresholds = self.config_note.content.get(
-            "perturbedmaximization_bad_match_thresholds", [0.1, 0.3, 0.5]
+            "perturbedmaximization_bad_match_thresholds", [0.1, 0.5, 1.0]
         )
 
         # Lazy variables

--- a/matcher/solvers/perturbed_maximization_solver.py
+++ b/matcher/solvers/perturbed_maximization_solver.py
@@ -91,7 +91,7 @@ class PerturbedMaximizationSolver:
         assignment = [[0.0 for j in range(self.num_revs)] for i in range(self.num_paps)]
         for i in range(self.num_paps):
             for j in range(self.num_revs):
-                if self.constraint_matrix[i][j] == -1:
+                if self.constraint_matrix[i][j] == -1 or self.cost_matrix[i][j] > 0:
                     x = solver.addVar(lb=0, ub=0, name=f"{i} {j}")
                 elif self.constraint_matrix[i][j] == 1:
                     x = solver.addVar(lb=1, ub=1, name=f"{i} {j}")
@@ -149,7 +149,7 @@ class PerturbedMaximizationSolver:
             ]
             for i in range(self.num_paps):
                 for j in range(self.num_revs):
-                    if self.constraint_matrix[i][j] == -1:
+                    if self.constraint_matrix[i][j] == -1 or self.cost_matrix[i][j] > 0:
                         x = solver.addVar(lb=0, ub=0, name=f"{i} {j}")
                     elif self.constraint_matrix[i][j] == 1:
                         x = solver.addVar(lb=1, ub=1, name=f"{i} {j}")
@@ -306,10 +306,10 @@ class PerturbedMaximizationSolver:
             )
 
         # Perturbation
-        if not isinstance(self.perturbation, float):
+        if not isinstance(self.perturbation, (float, int)):
             self.logger.debug("[PerturbedMaximization]: ERROR: Invaild input")
             raise SolverException(
-                "Perturbation must be of type float"
+                "Perturbation must be a number"
             )
         if not self.perturbation >= 0:
             self.logger.debug("[PerturbedMaximization]: ERROR: Invaild input")
@@ -324,10 +324,10 @@ class PerturbedMaximizationSolver:
                 "Bad match thresholds must be of type list"
             )
         for threshold in self.bad_match_thresholds:
-            if not isinstance(threshold, float):
+            if not isinstance(threshold, (float, int)):
                 self.logger.debug("[PerturbedMaximization]: ERROR: Invaild input")
                 raise SolverException(
-                    "Bad match thresholds must be a list of floats"
+                    "Bad match thresholds must be a list of numbers"
                 )
 
         # OR Validation
@@ -446,7 +446,7 @@ class PerturbedMaximizationSolver:
         assignment = [[0.0 for j in range(self.num_revs)] for i in range(self.num_paps)]
         for i in range(self.num_paps):
             for j in range(self.num_revs):
-                if self.constraint_matrix[i][j] == -1:
+                if self.constraint_matrix[i][j] == -1 or self.cost_matrix[i][j] > 0:
                     x = solver.addVar(lb=0, ub=0, name=f"{i} {j}")
                 elif self.constraint_matrix[i][j] == 1:
                     x = solver.addVar(lb=1, ub=1, name=f"{i} {j}")

--- a/tests/test_solvers_perturbed_maximization.py
+++ b/tests/test_solvers_perturbed_maximization.py
@@ -233,6 +233,15 @@ def test_impossible_constraints():
     solver.solve()
     assert not solver.solved  # not if minimum is 1
 
+    try:
+        solver = PerturbedMaximizationSolver(
+            [0, 0, 0, 0], [3, 3, 3, 3], [2, 2, 2], encoder(S, M, Q, 0.0)
+        )
+        solver.solve()
+        assert False  # should throw, no positive cost pairs
+    except SolverException:
+        pass
+
 
 def test_fractional_reviewer_load():
     """Test that sampling works correctly if some reviewer loads are fractional"""


### PR DESCRIPTION
This pull request changes the following three things:

1. It fixes the bug that input checking fails when some floating number parameters are integers.
2. It disallows negative matching scores to ensure the optimization is concave.
3. It updates the default values of the parameters `bad_match_thresholds` to the same with what was used in NeurIPS 2024.