### PR TITLE
Feat: Retry installs

### DIFF
--- a/.circleci/ci-utils.sh
+++ b/.circleci/ci-utils.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Retry function with exponential backoff
+retry() {
+  local max_attempts=5
+  local delay=5
+  local attempt=1
+  until "$@"; do
+    if (( attempt == max_attempts )); then
+      echo "Command failed after $attempt attempts."
+      return 1
+    fi
+    echo "Command failed. Retrying in $delay seconds... (Attempt $((attempt+1))/$max_attempts)"
+    sleep $delay
+    attempt=$(( attempt + 1 ))
+    delay=$(( delay * 2 ))
+  done
+}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,12 +30,15 @@ jobs:
       - run:
           name: Initialize replica set
           command: |
-            sudo apt-get install gnupg curl
+            # Source the utility functions  
+            source ~/openreview-matcher-repo/.circleci/ci-utils.sh
+
+            retry sudo apt-get install gnupg curl
             curl -fsSL https://pgp.mongodb.com/server-6.0.asc | sudo gpg -o /usr/share/keyrings/mongodb-server-6.0.gpg --dearmor
             echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-6.0.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/6.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-6.0.list
-            sudo apt-get update
-            sudo apt-get upgrade -y
-            sudo apt-get install -y mongodb-org=6.0.7
+            retry sudo apt-get update
+            retry sudo apt-get upgrade -y
+            retry sudo apt-get install -y mongodb-org=6.0.7
             mongosh mongodb://localhost:27017 --eval "rs.initiate()"
       - run:
           name: Clone OpenReview API V1 branch << pipeline.parameters.openreview-api-v1-branch >>
@@ -67,13 +70,16 @@ jobs:
           # source: https://ubuntu-mate.community/t/firefox-installation-guide-non-snap/25299
           name: Install Firefox
           command: |
+            # Source the utility functions  
+            source ~/openreview-matcher-repo/.circleci/ci-utils.sh
+
             wget "https://download.mozilla.org/?product=firefox-latest-ssl&os=linux64&lang=en-US" -O firefox-latest.tar.bz2
             tar -xvf firefox-*.tar.bz2
             sudo mv firefox /opt
             sudo ln -s /opt/firefox/firefox /usr/local/bin/firefox
-            sudo apt-get install libgtk-3-0
-            sudo apt-get install libasound2
-            sudo apt-get install libdbus-glib-1-2
+            retry sudo apt-get install libgtk-3-0
+            retry sudo apt-get install libasound2
+            retry sudo apt-get install libdbus-glib-1-2
             echo export PATH="$PATH:/usr/local/bin/firefox" >> ~/.bashrc
             source ~/.bashrc
       - run:


### PR DESCRIPTION

This pull request introduces a retry mechanism with exponential backoff for critical CI commands in the `.circleci` configuration. The main changes include adding a reusable `retry` function in a new utility script and updating CI jobs to use this function for improved reliability.

### Addition of a retry utility:
* [`.circleci/ci-utils.sh`](diffhunk://#diff-30654eec016a92028fc8baa2332f575e3e577cd193625e8d1e537050c8f0bc54R1-R18): Added a `retry` function with exponential backoff to handle command retries, ensuring robustness in case of transient failures.

### Updates to CI jobs for reliability:
* [`.circleci/config.yml`](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L33-R41): Updated the "Initialize replica set" job to source the `ci-utils.sh` script and wrap commands like `apt-get install`, `apt-get update`, and `apt-get upgrade` with the `retry` function.
* [`.circleci/config.yml`](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47R73-R82): Updated the "Install Firefox" job to source the `ci-utils.sh` script and use the `retry` function for installing dependencies like `libgtk-3-0`, `libasound2`, and `libdbus-glib-1-2`.