### PR TITLE
support filter by content that contains an &

### DIFF
--- a/matcher/service/openreview_interface.py
+++ b/matcher/service/openreview_interface.py
@@ -819,20 +819,19 @@ class ConfigNoteInterfaceV2(BaseConfigNoteInterface):
             self.logger.debug(
                 "Getting notes for invitation: {}".format(paper_invitation)
             )
-            if "&" in paper_invitation:
-                elements = paper_invitation.split("&")
-                paper_invitation = elements[0]
-                for element in elements[1:]:
-                    if element:
-                        if element.startswith("content.") and "=" in element:
-                            key, value = element.replace('content.', '').split("=")
-                            content_dict[key] = value
-                        else:
-                            self.logger.debug(
-                                'Invalid filter provided in invitation: {}. Supported filter format "content.field_x=value1".'.format(
-                                    element
-                                )
+            if "&content." in paper_invitation:
+                parts = paper_invitation.split("&content.")
+                paper_invitation = parts[0]
+                for part in parts[1:]:
+                    if "=" in part:
+                        key, value = part.split("=", 1)
+                        content_dict[key] = value
+                    else:
+                        self.logger.debug(
+                            'Invalid filter provided in invitation: {}. Supported filter format "content.field_x=value1".'.format(
+                                part
                             )
+                        )
             if "/-/" in paper_invitation:
                 paper_notes = self.client.get_all_notes(
                     invitation=paper_invitation,

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="openreview-matcher",
-    version="2.0.5",
+    version="2.0.6",
     description="OpenReview matching library",
     url="https://github.com/openreview/openreview-matcher",
     author="Michael Spector",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -187,7 +187,7 @@ def clean_start_conference_v2(
                         "title": {
                             "value": "Test_Paper_{}".format(paper_number)
                         },
-                        "abstract": {"value": f"Paper abstract {paper_number}"},
+                        "abstract": {"value": f"Paper abstract &{paper_number}"},
                         "authors": {"value": authors},
                         "authorids": {"value": authorids},
                         "pdf": {"value": "/pdf/" + "p" * 40 + ".pdf"},

--- a/tests/test_integration_api2_fairflow.py
+++ b/tests/test_integration_api2_fairflow.py
@@ -1118,7 +1118,7 @@ def test_integration_by_track(openreview_context, venue, celery_app, celery_sess
         "config_invitation": {
             "value": "{}/-/Assignment_Configuration".format(reviewers_id)
         },
-        "paper_invitation": {"value": venue.get_submission_id() + '&content.abstract=Paper abstract 1'},
+        "paper_invitation": {"value": venue.get_submission_id() + '&content.abstract=Paper abstract &1'},
         "assignment_invitation": {
             "value": venue.get_assignment_id(reviewers_id)
         },
@@ -1186,7 +1186,7 @@ def test_integration_by_track(openreview_context, venue, celery_app, celery_sess
         "config_invitation": {
             "value": "{}/-/Assignment_Configuration".format(reviewers_id)
         },
-        "paper_invitation": {"value": venue.get_submission_id() + '&content.track=Paper abstract 1'},
+        "paper_invitation": {"value": venue.get_submission_id() + '&content.track=Paper abstract &1'},
         "assignment_invitation": {
             "value": venue.get_assignment_id(reviewers_id)
         },

--- a/tests/test_integration_api2_perturbed_maximization.py
+++ b/tests/test_integration_api2_perturbed_maximization.py
@@ -1019,7 +1019,7 @@ def test_integration_by_track(openreview_context, venue, celery_app, celery_sess
         "config_invitation": {
             "value": "{}/-/Assignment_Configuration".format(reviewers_id)
         },
-        "paper_invitation": {"value": venue.get_submission_id() + '&content.abstract=Paper abstract 1'},
+        "paper_invitation": {"value": venue.get_submission_id() + '&content.abstract=Paper abstract &1'},
         "assignment_invitation": {
             "value": venue.get_assignment_id(reviewers_id)
         },
@@ -1087,7 +1087,7 @@ def test_integration_by_track(openreview_context, venue, celery_app, celery_sess
         "config_invitation": {
             "value": "{}/-/Assignment_Configuration".format(reviewers_id)
         },
-        "paper_invitation": {"value": venue.get_submission_id() + '&content.track=Paper abstract 1'},
+        "paper_invitation": {"value": venue.get_submission_id() + '&content.track=Paper abstract &1'},
         "assignment_invitation": {
             "value": venue.get_assignment_id(reviewers_id)
         },


### PR DESCRIPTION
The assignment configuration note let you specify which submissions to use to run the paper matching. By default you can use a note submission invitation plus more params to filter the notes by a field of the content. For example:

paper_invitation: 'ADScAI/2026/Conference/Submission&content.track=Undergraduate Research & Innovation'

The current code is splitting the paper_invitation value by '&' in order to get the content.track value to filter the notes.

This PR is changing how we split the value so we can keep the whole 'Undergraduate Research & Innovation' string to filter the notes by conten.track

Tests are updated